### PR TITLE
Improve material texture type

### DIFF
--- a/private/Producer/GenericProducer.h
+++ b/private/Producer/GenericProducer.h
@@ -2,6 +2,9 @@
 
 #include "Producer/BaseProducer.h"
 
+struct aiMaterial;
+struct aiMesh;
+
 namespace cdtools
 {
 
@@ -44,6 +47,8 @@ public:
 
 private:
 	uint32_t GetImportFlags() const;
+	void ParseMaterial(SceneDatabase* pSceneDatabase, const aiMaterial* pSourceMaterial) const;
+	void ParseMesh(SceneDatabase* pSceneDatabase, const aiMesh* pSourceMesh) const;
 
 private:
 	// Service flags

--- a/public/Scene/Material.h
+++ b/public/Scene/Material.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Core/ISerializable.hpp"
+#include "MaterialTextureType.h"
 #include "Math/VectorDerived.hpp"
 #include "ObjectIDTypes.h"
 
@@ -10,15 +11,6 @@
 
 namespace cdtools
 {
-
-enum class MaterialTextureType
-{
-	BaseColor = 0,
-	Normal,
-	Metalness,
-	Roughness,
-	Unknown,
-};
 
 class Material final : public ISerializable
 {
@@ -42,6 +34,7 @@ public:
 	void SetTextureID(MaterialTextureType textureType, TextureID textureID);
 	std::optional<TextureID> GetTextureID(MaterialTextureType textureType) const;
 	const TextureIDMap& GetTextureIDMap() const { return m_textureIDs; }
+	bool IsTextureTypeSetup(MaterialTextureType textureType) const { return m_textureIDs.find(textureType) != m_textureIDs.end(); }
 
 	// ISerializable
 	virtual void ImportBinary(std::ifstream& fin) override;

--- a/public/Scene/MaterialTextureType.h
+++ b/public/Scene/MaterialTextureType.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <inttypes.h>
+
+enum class MaterialTextureType : uint8_t
+{
+	BaseColor = 0,
+	Normal,
+	Metalness,
+	Roughness,
+	Emissive,
+	AO,
+	Count
+};
+
+constexpr const char* MaterialTextureTypeName[] =
+{
+	"BaseColor",
+	"Normal",
+	"Metalness",
+	"Roughness",
+	"Emissive",
+	"AO",
+};
+
+// Sanity check for enum and name mapping.
+static_assert(static_cast<int>(MaterialTextureType::Count) == sizeof(MaterialTextureTypeName) / sizeof(char*),
+	"Material texture types and names mismatch.");
+
+inline const char* GetMaterialTextureTypeName(MaterialTextureType textureType)
+{
+	return MaterialTextureTypeName[static_cast<int>(textureType)];
+}


### PR DESCRIPTION
It was not accurate about material texture types. So we write codes about "unknown" -> "ORM". And we don't know if the "ORM" texture really has AO channel. After it, we can improve runtime rendering by using `HAS_AO_MAP` as a uber shader compile flag.

// "ORM" means a workflow to combine ao, roughness, metalness in R/G/B channels in a texture.

![image](https://user-images.githubusercontent.com/75730859/200608818-2ae10789-1368-4db3-870f-b9e6e86a36bd.png)


TODO : It will be better if we know the R/G/B channel mapping. But I don't find any assimp apis about it.