### PR TITLE
Modified TerrainProducer for engine to consume.

### DIFF
--- a/examples/GenerateTerrainToCatDog/Main.cpp
+++ b/examples/GenerateTerrainToCatDog/Main.cpp
@@ -20,7 +20,7 @@ int main(int argc, char** argv)
 
 	const char* pInputFilePath = argv[1];
 	const char* pOutputFilePath = argv[2];
-	TerrainProducer producer(256, 256, 500, 500, 6000);
+	TerrainProducer producer(256, 256, 50, 50, 2000);
 	CatDogConsumer consumer(pOutputFilePath);
 	consumer.SetExportMode(cdtools::ExportMode::PureBinary);
 	// FbxConsumer consumer(pOutputFilePath);

--- a/private/Producer/TerrainProducer.h
+++ b/private/Producer/TerrainProducer.h
@@ -6,6 +6,8 @@
 #include "Math/AABB.hpp"
 #include "Math/VectorDerived.hpp"
 #include "Producer/IProducer.h"
+#include "Scene/ObjectIDGenerator.h"
+
 namespace cdtools
 {
 
@@ -38,9 +40,9 @@ public:
 	virtual void Execute(SceneDatabase* pSceneDatabase) override;
 
 private:
+	Mesh CreateTerrainMesh();
 	TerrainQuad CreateQuadAt(uint32_t& currentVertexId, uint32_t& currentPolygonId) const;
 	float GetHeightAt(uint32_t x, uint32_t z, const std::vector<std::pair<float, int64_t>>& freq_params, float power_exp) const;
-	AABB CalculateAABB(const Mesh& mesh);
 
 	uint32_t m_numQuadsInX;		// quads in x-axis
 	uint32_t m_numQuadsInZ;		// quads in z-axis
@@ -48,6 +50,9 @@ private:
 	uint32_t m_quadHeight;		// height of a quad
 	uint32_t m_maxElevation;	// highest possible elevation; we start at 0.
 
+	ObjectIDGenerator<MeshID> m_meshIDGenerator;
+	ObjectIDGenerator<MaterialID> m_materialIDGenerator;
+	ObjectIDGenerator<TextureID> m_textureIDGenerator;
 };
 
 }	// namespace cdtools

--- a/private/Utilities/MeshUtils.h
+++ b/private/Utilities/MeshUtils.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Math/AABB.hpp"
+#include "Math/VectorDerived.hpp"
+#include "Scene/Mesh.h"
+
+namespace cdtools
+{
+	AABB CalculateAABB(const Mesh& mesh)
+	{
+		Point minPoint;
+		Point maxPoint;
+		const std::vector<Point>& meshPoints = mesh.GetVertexPositions();
+		for (uint32_t i = 0; i < meshPoints.size(); ++i)
+		{
+			const Point& current = meshPoints[i];
+			minPoint[0] = std::min(current[0], minPoint[0]);
+			minPoint[1] = std::min(current[1], minPoint[1]);
+			minPoint[2] = std::min(current[2], minPoint[2]);
+			maxPoint[0] = std::max(current[0], maxPoint[0]);
+			maxPoint[1] = std::max(current[1], maxPoint[1]);
+			maxPoint[2] = std::max(current[2], maxPoint[2]);
+		}
+		return AABB(minPoint, maxPoint);
+	}
+}

--- a/public/Scene/SceneDatabase.h
+++ b/public/Scene/SceneDatabase.h
@@ -28,6 +28,7 @@ public:
 	const std::string& GetName() const { return m_name; }
 	
 	void SetAABB(AABB aabb) { m_aabb = std::move(aabb); }
+	AABB& GetAABB() { return m_aabb; }
 	const AABB& GetAABB() const { return m_aabb; }
 
 	// mesh


### PR DESCRIPTION
This PR contains the following changes in AssetPipeline:
1. Modified terrain generation param to better fit engine consumption.
2. Modified SceneDatabase to allow AABB to be modified. This can be used during scene generation.
3. Modified terrain to output materials that match mesh index. Later this will be changed to be sectorized. 
4. Made TerrainProducer to consume the new ID generators instead of getting mesh ID from scene. 
5. Extract AABB calculation of mesh to a utility class.