### PR TITLE
Implemented byte_swap

### DIFF
--- a/private/Producer/TerrainProducer.cpp
+++ b/private/Producer/TerrainProducer.cpp
@@ -51,20 +51,20 @@ void TerrainProducer::Execute(cd::SceneDatabase* pSceneDatabase)
 	pSceneDatabase->AddMaterial(baseColorMaterial);
 	pSceneDatabase->AddTexture(cd::Texture(textureID, textureName.c_str()));
 
-	isUsed = false;
-	materialName = "testColor";
-	materialHash = cd::StringHash<cd::MaterialID::ValueType>(materialName);
-	cd::MaterialID testMaterialID = m_materialIDGenerator.AllocateID(materialHash, isUsed);
-	cd::Material testColorMaterial(testMaterialID, materialName.c_str());
-
-	// TODO get this from file later
-	isUsed = false;
-	textureName = "TestColorTexture";
-	textureHash = cd::StringHash<cd::TextureID::ValueType>(textureName);
-	textureID = m_textureIDGenerator.AllocateID(textureHash, isUsed);
-	testColorMaterial.SetTextureID(cd::MaterialTextureType::BaseColor, textureID);
-	pSceneDatabase->AddMaterial(testColorMaterial);
-	pSceneDatabase->AddTexture(cd::Texture(textureID, textureName.c_str()));
+// 	isUsed = false;
+// 	materialName = "testColor";
+// 	materialHash = cd::StringHash<cd::MaterialID::ValueType>(materialName);
+// 	cd::MaterialID testMaterialID = m_materialIDGenerator.AllocateID(materialHash, isUsed);
+// 	cd::Material testColorMaterial(testMaterialID, materialName.c_str());
+// 
+// 	// TODO get this from file later
+// 	isUsed = false;
+// 	textureName = "TestColorTexture";
+// 	textureHash = cd::StringHash<cd::TextureID::ValueType>(textureName);
+// 	textureID = m_textureIDGenerator.AllocateID(textureHash, isUsed);
+// 	testColorMaterial.SetTextureID(cd::MaterialTextureType::BaseColor, textureID);
+// 	pSceneDatabase->AddMaterial(testColorMaterial);
+// 	pSceneDatabase->AddTexture(cd::Texture(textureID, textureName.c_str()));
 
 	cd::Mesh terrain = CreateTerrainMesh();
 	terrain.SetMaterialID(materialID.Data());

--- a/public/IO/InputArchive.hpp
+++ b/public/IO/InputArchive.hpp
@@ -2,6 +2,8 @@
 
 #include <istream>
 
+#include "Utilities/ByteSwap.h"
+
 namespace cd
 {
 
@@ -41,7 +43,8 @@ public:
 		m_pIStream->read(reinterpret_cast<char*>(&bufferBytes), sizeof(size_t));
 		if constexpr (SwapBytesOrder)
 		{
-			bufferBytes = std::byteswap(bufferBytes);
+			// bufferBytes = std::byteswap(bufferBytes);
+			bufferBytes = byte_swap<size_t>(bufferBytes);
 		}
 		m_pIStream->read(reinterpret_cast<char*>(data), bufferBytes);
 	}
@@ -55,7 +58,8 @@ public:
 			m_pIStream->read(reinterpret_cast<char*>(&data), sizeof(data));
 			if constexpr (SwapBytesOrder)
 			{
-				data = std::byteswap(data);
+				// data = std::byteswap(data);
+				data = byte_swap<T>(data);
 			}
 		}
 		else if constexpr (std::is_floating_point_v<T>)
@@ -63,11 +67,13 @@ public:
 			m_pIStream->read(reinterpret_cast<char*>(&data), sizeof(data));
 			if constexpr (4 == sizeof(T))
 			{
-				data = std::byteswap(static_cast<uint32_t>(data));
+				// data = std::byteswap(static_cast<uint32_t>(data));
+				data = byte_swap<float>(data);
 			}
 			else if constexpr (8 == sizeof(T))
 			{
-				data = std::byteswap(static_cast<uint64_t>(data));
+				// data = std::byteswap(static_cast<uint64_t>(data));
+				data = byte_swap<double>(data);
 			}
 			else
 			{
@@ -80,7 +86,8 @@ public:
 			m_pIStream->read(reinterpret_cast<char*>(&dataLength), sizeof(size_t));
 			if constexpr (SwapBytesOrder)
 			{
-				dataLength = std::byteswap(dataLength);
+				// dataLength = std::byteswap(dataLength);
+				dataLength = byte_swap<size_t>(dataLength);
 			}
 			data.resize(dataLength);
 			m_pIStream->read(reinterpret_cast<char*>(data.data()), dataLength);

--- a/public/IO/OutputArchive.hpp
+++ b/public/IO/OutputArchive.hpp
@@ -2,6 +2,8 @@
 
 #include <ostream>
 
+#include "Utilities/ByteSwap.h"
+
 namespace cd
 {
 
@@ -39,7 +41,8 @@ public:
 		size_t bufferBytes = size * sizeof(std::remove_pointer_t<T>);
 		if constexpr (SwapBytesOrder)
 		{
-			bufferBytes = std::byteswap(bufferBytes);
+			// bufferBytes = std::byteswap(bufferBytes);
+			bufferBytes = byte_swap<size_t>(bufferBytes);
 		}
 
 		m_pOStream->write(reinterpret_cast<const char*>(&bufferBytes), sizeof(size_t));
@@ -56,7 +59,8 @@ private:
 		{
 			if constexpr (SwapBytesOrder)
 			{
-				T checkedData = std::byteswap(data);
+				// T checkedData = std::byteswap(data);
+				T checkedData = byte_swap<T>(data);
 				m_pOStream->write(reinterpret_cast<const char*>(&checkedData), sizeof(T));
 			}
 			else
@@ -70,12 +74,14 @@ private:
 			{
 				if constexpr (4 == sizeof(T))
 				{
-					uint32_t checkedData = std::byteswap(static_cast<uint32_t>(data));
+					// uint32_t checkedData = std::byteswap(static_cast<uint32_t>(data));
+					float checkedData = byte_swap<float>(data);
 					m_pOStream->write(reinterpret_cast<const char*>(&checkedData), sizeof(T));
 				}
 				else if constexpr (8 == sizeof(T))
 				{
-					uint64_t checkedData = std::byteswap(static_cast<uint64_t>(data));
+					// uint64_t checkedData = std::byteswap(static_cast<uint64_t>(data));
+					double checkedData = byte_swap<double>(data);
 					m_pOStream->write(reinterpret_cast<const char*>(&checkedData), sizeof(T));
 				}
 				else
@@ -94,7 +100,8 @@ private:
 			if constexpr (SwapBytesOrder)
 			{
 				// std::string is just array of 1 byte char so don't need to swap bytes.
-				dataLength = std::byteswap(dataLength);
+				// dataLength = std::byteswap(dataLength);
+				dataLength = byte_swap<size_t>(dataLength);
 			}
 
 			m_pOStream->write(reinterpret_cast<const char*>(&dataLength), sizeof(size_t));

--- a/public/Utilities/ByteSwap.h
+++ b/public/Utilities/ByteSwap.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace cd
+{
+
+// Due to non-universal support of C++23, simply implement byte swap here
+template<typename T, size_t sz>
+struct swap_bytes
+{
+	inline T operator()(T val)
+	{
+		throw std::out_of_range("T data size");
+	}
+};
+
+// byte_swap for 1 byte
+template<typename T>
+struct swap_bytes<T, 1>
+{
+	inline T operator()(T val)
+	{
+		return val;
+	}
+};
+
+// byte_swap for 2 bytes
+template<typename T>
+struct swap_bytes<T, 2>
+{
+	inline T operator()(T val)
+	{
+		return ((((val) >> 8) & 0xff) | (((val) & 0xff) << 8));
+	}
+};
+
+// byte_swap for 4 bytes
+template<typename T>
+struct swap_bytes<T, 4>
+{
+	inline T operator()(T val)
+	{
+		return ((((val) & 0xff000000) >> 24) | (((val) & 0x00ff0000) >> 8) | (((val) & 0x0000ff00) << 8) | (((val) & 0x000000ff) << 24));
+	}
+};
+
+// byte_swap for float
+template<>
+struct swap_bytes<float, 4>
+{
+	inline float operator()(float val)
+	{
+		uint32_t mem = swap_bytes<uint32_t, sizeof(uint32_t)>()(*(reinterpret_cast<uint32_t*>(&val)));
+		return *(reinterpret_cast<float*>(&mem));
+	}
+};
+
+// byte_swap for 8 bytes
+template<typename T>
+struct swap_bytes<T, 8>
+{
+	inline T operator()(T val)
+	{
+		return ((((val) & 0xff00000000000000ull) >> 56) | (((val) & 0x00ff000000000000ull) >> 40) | (((val) & 0x0000ff0000000000ull) >> 24) | (((val) & 0x000000ff00000000ull) >> 8) |
+			   (((val) & 0x00000000ff000000ull) << 8) | (((val) & 0x0000000000ff0000ull) << 24) | (((val) & 0x000000000000ff00ull) << 40) | (((val) & 0x00000000000000ffull) << 56));
+	}
+};
+
+// double
+template<>
+struct swap_bytes<double, 8>
+{
+	inline double operator()(double val)
+	{
+		uint64_t mem = swap_bytes<uint64_t, sizeof(uint64_t)>()(*(reinterpret_cast<uint64_t*>(&val)));
+		return *(reinterpret_cast<double*>(&mem));
+	}
+};
+
+template<typename T>
+inline T byte_swap(T value)
+{
+	static_assert(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8);
+	static_assert(std::is_arithmetic_v<T>);
+	return swap_bytes<T, sizeof(T)>()(value);
+}
+
+}


### PR DESCRIPTION
Due to std:;byteswap is only for C++23, this implementation will allow compatibility for C++ compilers prior to version 2023.