### PR TITLE
Upgrade action version and reduce package size

### DIFF
--- a/.github/workflows/linux_gmake2.yml
+++ b/.github/workflows/linux_gmake2.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.2.0
 
     - name: Checkout submodules
       run: git submodule update --init --recursive
@@ -21,12 +21,15 @@ jobs:
       run: |
         chmod +x ${{github.workspace}}/make_linux_gmake2.sh
         bash ${{github.workspace}}/make_linux_gmake2.sh
-    - name: Use makefile to compile
-      run: make
+    - name: Use makefile to compile debug version
+      run: make config=debug
+    - name: Use makefile to compile release version
+      run: make config=release
     - name: Upload built results to Artifact
       uses: actions/upload-artifact@v3.1.1
       with:
         name: cdscene_sdk_linux_gmake2
         path: |
           ${{github.workspace}}/public/**/*.*
-          ${{github.workspace}}/build/bin/**/*.*
+          ${{github.workspace}}/build/bin/**/AssetPipelineCore.*
+          ${{github.workspace}}/build/bin/**/CDProducer.*

--- a/.github/workflows/win64_vs2019.yml
+++ b/.github/workflows/win64_vs2019.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.2.0
       
     - name: Checkout submodules
       run: git submodule update --init --recursive
@@ -21,7 +21,7 @@ jobs:
       run: ${{github.workspace}}/make_win64_vs2019.bat
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
 
     - name: Build Debugx64
       run: msbuild ${{github.workspace}}/AssetPipeline.sln /p:Configuration=Debug /p:Platform=x64
@@ -35,4 +35,5 @@ jobs:
         name: cdscene_sdk_win64_vs2019
         path: |
           ${{github.workspace}}/public/**/*.*
-          ${{github.workspace}}/build/bin/**/*.*
+          ${{github.workspace}}/build/bin/**/AssetPipelineCore.*
+          ${{github.workspace}}/build/bin/**/CDProducer.*

--- a/.github/workflows/win64_vs2022.yml
+++ b/.github/workflows/win64_vs2022.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.2.0
       
     - name: Checkout submodules
       run: git submodule update --init --recursive
@@ -21,7 +21,7 @@ jobs:
       run: ${{github.workspace}}/make_win64_vs2022.bat
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
 
     - name: Build Debugx64
       run: msbuild ${{github.workspace}}/AssetPipeline.sln /p:Configuration=Debug /p:Platform=x64
@@ -35,4 +35,5 @@ jobs:
         name: cdscene_sdk_win64_vs2022
         path: |
           ${{github.workspace}}/public/**/*.*
-          ${{github.workspace}}/build/bin/**/*.*
+          ${{github.workspace}}/build/bin/**/AssetPipelineCore.*
+          ${{github.workspace}}/build/bin/**/CDProducer.*


### PR DESCRIPTION
As github action decided to deprecate node js 12, some action will be unavailable after 2023 summer.