### PR TITLE
Refactor material.

### DIFF
--- a/private/Consumers/CDConsumer/CDConsumerImpl.cpp
+++ b/private/Consumers/CDConsumer/CDConsumerImpl.cpp
@@ -141,13 +141,30 @@ void CDConsumerImpl::ExportXmlBinary(const cd::SceneDatabase* pSceneDatabase)
 		WriteNodeStringAttribute(pMaterialNode, "Name", material.GetName());
 
 		XmlNode* pMaterialDataNode = WriteNode("Data");
-		WriteNodeU32Attribute(pMaterialDataNode, "TextureCount", static_cast<uint32_t>(material.GetTextureIDMap().size()));
+		XmlNode *pTextureListNode = WriteNode("TextureList");
 
-		XmlNode* pTextureListNode = WriteNode("TextureList");
-		for (const auto& [materialTextureType, textureID] : material.GetTextureIDMap())
+		std::vector<cd::MaterialTextureType> textureTypes = {
+			cd::MaterialTextureType::BaseColor,
+			cd::MaterialTextureType::Occlusion,
+			cd::MaterialTextureType::Roughness,
+			cd::MaterialTextureType::Metallic,
+			cd::MaterialTextureType::Emissive,
+			cd::MaterialTextureType::Normal,
+		};
+
+		for (const auto &textureType : textureTypes)
 		{
-			XmlNode* pTextureNode = WriteNode(GetMaterialTextureTypeName(materialTextureType), std::to_string(textureID.Data()).c_str());
-			pTextureListNode->append_node(pTextureNode);
+			std::string textureKey = GetMaterialPropretyTextureKey(textureType);
+			const auto &map = material.GetMaterialType();
+			const std::optional<uint32_t> textureID = map.Get<uint32_t>(textureKey);
+
+			if (textureID.has_value())
+			{
+				std::stringstream ss;
+				ss << textureID.value();
+				XmlNode* pTextureNode = WriteNode(GetMaterialPropretyGroupName(textureType), ss.str().c_str());
+				pTextureListNode->append_node(pTextureNode);
+			}
 		}
 
 		pMaterialNode->append_node(pMaterialDataNode);

--- a/private/Consumers/CDConsumer/CDConsumerImpl.cpp
+++ b/private/Consumers/CDConsumer/CDConsumerImpl.cpp
@@ -152,17 +152,13 @@ void CDConsumerImpl::ExportXmlBinary(const cd::SceneDatabase* pSceneDatabase)
 			cd::MaterialTextureType::Normal,
 		};
 
-		for (const auto &textureType : textureTypes)
+		for (const auto &type : textureTypes)
 		{
-			std::string textureKey = GetMaterialPropertyTextureKey(textureType);
-			const auto &groups = material.GetPropertyGroups();
-			const std::optional<uint32_t> textureID = groups.Get<uint32_t>(textureKey);
-
-			if (textureID.has_value())
+			if (material.IsTextureSetup(type))
 			{
 				std::stringstream ss;
-				ss << textureID.value();
-				XmlNode* pTextureNode = WriteNode(GetMaterialPropertyGroupName(textureType), ss.str().c_str());
+				ss << material.GetTextureID(type).value().Data();
+				XmlNode *pTextureNode = WriteNode(GetMaterialPropertyGroupName(type), ss.str().c_str());
 				pTextureListNode->append_node(pTextureNode);
 			}
 		}

--- a/private/Consumers/CDConsumer/CDConsumerImpl.cpp
+++ b/private/Consumers/CDConsumer/CDConsumerImpl.cpp
@@ -154,15 +154,15 @@ void CDConsumerImpl::ExportXmlBinary(const cd::SceneDatabase* pSceneDatabase)
 
 		for (const auto &textureType : textureTypes)
 		{
-			std::string textureKey = GetMaterialPropretyTextureKey(textureType);
-			const auto &map = material.GetMaterialType();
-			const std::optional<uint32_t> textureID = map.Get<uint32_t>(textureKey);
+			std::string textureKey = GetMaterialPropertyTextureKey(textureType);
+			const auto &groups = material.GetPropertyGroups();
+			const std::optional<uint32_t> textureID = groups.Get<uint32_t>(textureKey);
 
 			if (textureID.has_value())
 			{
 				std::stringstream ss;
 				ss << textureID.value();
-				XmlNode* pTextureNode = WriteNode(GetMaterialPropretyGroupName(textureType), ss.str().c_str());
+				XmlNode* pTextureNode = WriteNode(GetMaterialPropertyGroupName(textureType), ss.str().c_str());
 				pTextureListNode->append_node(pTextureNode);
 			}
 		}

--- a/private/Producers/GenericProducer/GenericProducerImpl.cpp
+++ b/private/Producers/GenericProducer/GenericProducerImpl.cpp
@@ -97,7 +97,7 @@ void DumpSceneDatabase(const cd::SceneDatabase& sceneDatabase)
 			}
 			else
 			{
-				printf("\t[warnning] Can not find texture id by textureKey %s\n", textureKey.c_str());
+				// printf("\t[warnning] Can not find texture id by textureKey %s\n", textureKey.c_str());
 			}
 		}
 	}

--- a/private/Producers/GenericProducer/GenericProducerImpl.cpp
+++ b/private/Producers/GenericProducer/GenericProducerImpl.cpp
@@ -197,11 +197,11 @@ cd::MaterialID GenericProducerImpl::AddMaterial(cd::SceneDatabase* pSceneDatabas
 	cd::Material material(materialID, finalMaterialName.c_str());
 
 	// Process all textures
-	for (const auto& [textureType, materialPropretyGroup] : materialTextureMapping)
+	for (const auto& [textureType, materialTextureType] : materialTextureMapping)
 	{
 		// Multiple assimp texture types will map to the same texture to increase the successful rate.
 		// Setup means one assimp texture type already added. Just skip remain assimp texture types.
-		if (material.IsTextureTypeSetup(materialPropretyGroup))
+		if (material.IsTextureTypeSetup(materialTextureType))
 		{
 			continue;
 		}
@@ -241,12 +241,12 @@ cd::MaterialID GenericProducerImpl::AddMaterial(cd::SceneDatabase* pSceneDatabas
 			std::filesystem::path textureAbsolutePath = m_folderPath;
 			textureAbsolutePath.append(ai_path.C_Str());
 
-			material.SetTextureID(materialPropretyGroup, textureID);
+			material.SetTextureID(materialTextureType, textureID);
 
 			// Reused textures don't need to add to SceneDatabase again.
 			if (!isTextureReused)
 			{
-				pSceneDatabase->AddTexture(cd::Texture(textureID, materialPropretyGroup, textureAbsolutePath.generic_string().c_str()));
+				pSceneDatabase->AddTexture(cd::Texture(textureID, materialTextureType, textureAbsolutePath.generic_string().c_str()));
 			}
 		}
 	}

--- a/private/Producers/GenericProducer/GenericProducerImpl.cpp
+++ b/private/Producers/GenericProducer/GenericProducerImpl.cpp
@@ -83,17 +83,14 @@ void DumpSceneDatabase(const cd::SceneDatabase& sceneDatabase)
 	{
 		printf("[MaterialID %u] %s\n", material.GetID().Data(), material.GetName());
 
-		for (const auto &textureType : textureTypes)
+		for (const auto &type : textureTypes)
 		{
-			std::string textureKey = cd::GetMaterialPropertyTextureKey(textureType);
-			const auto &groups = material.GetPropertyGroups();
-			const auto textureID = groups.Get<uint32_t>(textureKey);
-			
-			if (textureID.has_value())
+			if (material.IsTextureSetup(type))
 			{
-				const auto &texture = sceneDatabase.GetTexture(textureID.value());
+				const auto &textureID = material.GetTextureID(type);
+				const auto &texture = sceneDatabase.GetTexture(textureID.value().Data());
 				printf("\t[TextureID %u] %s - %s\n", textureID.value(),
-					cd::GetMaterialPropertyGroupName(textureType), texture.GetPath());
+					cd::GetMaterialPropertyGroupName(type), texture.GetPath());
 			}
 			else
 			{

--- a/private/Producers/TerrainProducer/TerrainProducerImpl.cpp
+++ b/private/Producers/TerrainProducer/TerrainProducerImpl.cpp
@@ -217,20 +217,20 @@ void TerrainProducerImpl::GenerateMaterialAndTextures(cd::SceneDatabase* pSceneD
 	const std::string materialName = string_format("TerrainMaterial({}, {})", sector_x, sector_z);
 	MaterialID::ValueType materialHash = StringHash<MaterialID::ValueType>(materialName);
 	MaterialID materialID = m_materialIDGenerator.AllocateID(materialHash);
-	Material terrainSectorMaterial(materialID, materialName.c_str());
+	Material terrainSectorMaterial(materialID, materialName.c_str(), MaterialType::BasePBR);
 
 	// Base color texture
 	std::string textureName = "TerrainDirtTexture";
 	TextureID::ValueType textureHash = StringHash<TextureID::ValueType>(textureName);
 	TextureID textureID = m_textureIDGenerator.AllocateID(textureHash);
-	terrainSectorMaterial.SetTextureID(MaterialTextureType::BaseColor, textureID);
+	terrainSectorMaterial.AddTextureID(MaterialTextureType::BaseColor, textureID);
 	pSceneDatabase->AddTexture(Texture(textureID, MaterialTextureType::BaseColor, textureName.c_str()));
 
 	// ElevationMap texture
 	textureName = string_format("TerrainElevationMap({}, {})", sector_x, sector_z);
 	textureHash = StringHash<TextureID::ValueType>(textureName);
 	textureID = m_textureIDGenerator.AllocateID(textureHash);
-	terrainSectorMaterial.SetTextureID(MaterialTextureType::Roughness, textureID);
+	terrainSectorMaterial.AddTextureID(MaterialTextureType::Roughness, textureID);
 	Texture elevationTexture = Texture(textureID, MaterialTextureType::Roughness, textureName.c_str());
 	elevationTexture.SetRawTexture(elevationMap, TextureFormat::R32I);
 	pSceneDatabase->AddTexture(MoveTemp(elevationTexture));

--- a/private/Scene/Material.cpp
+++ b/private/Scene/Material.cpp
@@ -64,9 +64,8 @@ std::optional<TextureID> Material::GetTextureID(MaterialTextureType textureType)
 	return m_pMaterialImpl->GetTextureID(textureType);
 }
 
-const Material::TextureIDMap& Material::GetTextureIDMap() const
-{
-	return m_pMaterialImpl->GetTextureIDMap();
+const PropertyMap& Material::GetMaterialType() const {
+	return m_pMaterialImpl->GetMaterialType();
 }
 
 bool Material::IsTextureTypeSetup(MaterialTextureType textureType) const

--- a/private/Scene/Material.cpp
+++ b/private/Scene/Material.cpp
@@ -14,9 +14,9 @@ Material::Material(InputArchiveSwapBytes& inputArchive)
 	m_pMaterialImpl = new MaterialImpl(inputArchive);
 }
 
-Material::Material(MaterialID materialID, const char* pMaterialName)
+Material::Material(MaterialID materialID, const char* pMaterialName, MaterialType type)
 {
-	m_pMaterialImpl = new MaterialImpl(materialID, pMaterialName);
+	m_pMaterialImpl = new MaterialImpl(materialID, pMaterialName, type);
 }
 
 Material::Material(Material&& rhs)
@@ -39,9 +39,9 @@ Material::~Material()
 	}
 }
 
-void Material::Init(MaterialID materialID, const char* pMaterialName)
+void Material::Init(MaterialID materialID, const char* pMaterialName, MaterialType type)
 {
-	m_pMaterialImpl->Init(materialID, pMaterialName);
+	m_pMaterialImpl->Init(materialID, pMaterialName, type);
 }
 
 const MaterialID& Material::GetID() const
@@ -54,9 +54,9 @@ const char* Material::GetName() const
 	return m_pMaterialImpl->GetName().c_str();
 }
 
-void Material::SetTextureID(MaterialTextureType textureType, TextureID textureID)
+void Material::AddTextureID(MaterialTextureType textureType, TextureID textureID)
 {
-	m_pMaterialImpl->SetTextureID(textureType, textureID);
+	m_pMaterialImpl->AddTextureID(textureType, textureID);
 }
 
 std::optional<TextureID> Material::GetTextureID(MaterialTextureType textureType) const
@@ -64,13 +64,13 @@ std::optional<TextureID> Material::GetTextureID(MaterialTextureType textureType)
 	return m_pMaterialImpl->GetTextureID(textureType);
 }
 
-const PropertyMap& Material::GetMaterialType() const {
-	return m_pMaterialImpl->GetMaterialType();
+const PropertyMap& Material::GetPropertyGroups() const {
+	return m_pMaterialImpl->GetPropertyGroups();
 }
 
-bool Material::IsTextureTypeSetup(MaterialTextureType textureType) const
+bool Material::IsTextureSetup(MaterialTextureType textureType) const
 {
-	return m_pMaterialImpl->IsTextureTypeSetup(textureType);
+	return m_pMaterialImpl->IsTextureSetup(textureType);
 }
 
 Material& Material::operator<<(InputArchive& inputArchive)

--- a/private/Scene/MaterialImpl.cpp
+++ b/private/Scene/MaterialImpl.cpp
@@ -79,7 +79,7 @@ std::optional<TextureID> MaterialImpl::GetTextureID(MaterialPropertyGroup proper
 
 bool MaterialImpl::IsTextureSetup(MaterialPropertyGroup propertyGroup) const
 {
-	return ExtstProperty(propertyGroup, MaterialProperty::Texture);
+	return ExistProperty(propertyGroup, MaterialProperty::Texture);
 }
 
 }

--- a/private/Scene/MaterialImpl.cpp
+++ b/private/Scene/MaterialImpl.cpp
@@ -30,31 +30,27 @@ void MaterialImpl::Init(MaterialID materialID, std::string materialName, Materia
 
 void MaterialImpl::InitBasePBR()
 {
-	PropertyMap basePBR;
-
-	basePBR.Add("BaseColor_Color", Vec3f(1.0f, 1.0f, 1.0f));
+	AddProperty(MaterialPropertyGroup::BaseColor, MaterialProperty::Color, Vec3f(1.0f, 1.0f, 1.0f));
 	// Factor for blending Color and Texture.
 	// Or if there is no Texture, then this simply scales the Color value.
-	basePBR.Add("BaseColor_Factor", 0.0f);
-	basePBR.Add("BaseColor_UseTexture", true);
+	AddProperty(MaterialPropertyGroup::BaseColor, MaterialProperty::Factor, 0.0f);
+	AddProperty(MaterialPropertyGroup::BaseColor, MaterialProperty::UseTexture, true);
 
-	basePBR.Add("Occlusion_Factor", 0.0f);
-	basePBR.Add("Occlusion_UseTexture", true);
+	AddProperty(MaterialPropertyGroup::Occlusion, MaterialProperty::Factor, 0.0f);
+	AddProperty(MaterialPropertyGroup::Occlusion, MaterialProperty::UseTexture, true);
 
-	basePBR.Add("Roughness_Factor", 0.9f);
-	basePBR.Add("Roughness_UseTexture", true);
+	AddProperty(MaterialPropertyGroup::Roughness, MaterialProperty::Factor, 0.9f);
+	AddProperty(MaterialPropertyGroup::Roughness, MaterialProperty::UseTexture, true);
 
-	basePBR.Add("Metallic_Factor", 0.1f);
-	basePBR.Add("Metallic_UseTexture", true);
+	AddProperty(MaterialPropertyGroup::Metallic, MaterialProperty::Factor, 0.1f);
+	AddProperty(MaterialPropertyGroup::Metallic, MaterialProperty::UseTexture, true);
 
-	basePBR.Add("Normal_UseTexture", true);
+	AddProperty(MaterialPropertyGroup::Normal, MaterialProperty::UseTexture, true);
 
-	basePBR.Add("General_EnableDirectionalLights", true);
-	basePBR.Add("General_EnablePunctualLights", true);
-	basePBR.Add("General_EnableAreaLights", false);
-	basePBR.Add("General_EnableIBL", true);
-
-	m_propertyGroups = std::move(basePBR);
+	AddProperty(MaterialPropertyGroup::General, MaterialProperty::EnableDirectionalLights, true);
+	AddProperty(MaterialPropertyGroup::General, MaterialProperty::EnablePunctualLights, true);
+	AddProperty(MaterialPropertyGroup::General, MaterialProperty::EnableAreaLights, false);
+	AddProperty(MaterialPropertyGroup::General, MaterialProperty::EnableIBL, true);
 }
 
 void MaterialImpl::AddTextureID(MaterialPropertyGroup propertyGroup, TextureID textureID)

--- a/private/Scene/MaterialImpl.cpp
+++ b/private/Scene/MaterialImpl.cpp
@@ -21,9 +21,7 @@ void MaterialImpl::SetPropertyDefaultValue()
 {
 	m_basePBRMaterialType.Add("Name", std::string("BasePBR"));
 
-	m_basePBRMaterialType.Add("BaseColor_Color_R", 1.0f);
-	m_basePBRMaterialType.Add("BaseColor_Color_G", 1.0f);
-	m_basePBRMaterialType.Add("BaseColor_Color_B", 1.0f);
+	m_basePBRMaterialType.Add("BaseColor_Color", Vec3f(1.0f, 1.0f, 1.0f));
 	m_basePBRMaterialType.Add("BaseColor_Factor", 0.0f);
 	m_basePBRMaterialType.Add("BaseColor_UseTexture", true);
 

--- a/private/Scene/MaterialImpl.cpp
+++ b/private/Scene/MaterialImpl.cpp
@@ -8,6 +8,17 @@ namespace cd
 MaterialImpl::MaterialImpl(MaterialID materialID, std::string materialName, MaterialType materialType)
 {
 	Init(materialID, MoveTemp(materialName), materialType);
+
+	switch (materialType)
+	{
+		case MaterialType::BasePBR:
+			InitBasePBR();
+			break;
+
+		default:
+			printf("Unknow material type!\n");
+			break;
+	}
 }
 
 void MaterialImpl::Init(MaterialID materialID, std::string materialName, MaterialType materialType)

--- a/private/Scene/MaterialImpl.cpp
+++ b/private/Scene/MaterialImpl.cpp
@@ -8,6 +8,7 @@ namespace cd
 MaterialImpl::MaterialImpl(MaterialID materialID, std::string materialName)
 {
 	Init(materialID, MoveTemp(materialName));
+	SetPropertyDefaultValue();
 }
 
 void MaterialImpl::Init(MaterialID materialID, std::string materialName)
@@ -16,31 +17,55 @@ void MaterialImpl::Init(MaterialID materialID, std::string materialName)
 	m_name = MoveTemp(materialName);
 }
 
-void MaterialImpl::SetTextureID(MaterialTextureType textureType, TextureID textureID)
+void MaterialImpl::SetPropertyDefaultValue()
 {
-	TextureIDMap::iterator itTexture = m_textureIDs.find(textureType);
-	if(itTexture != m_textureIDs.end())
-	{
-		// Existed!
-		if(textureID == itTexture->second)
-		{
-			// Same
-			return;
-		}
-	}
+	m_basePBRMaterialType.Add("Name", std::string("BasePBR"));
 
-	m_textureIDs[textureType] = textureID;
+	m_basePBRMaterialType.Add("BaseColor_Color_R", 1.0f);
+	m_basePBRMaterialType.Add("BaseColor_Color_G", 1.0f);
+	m_basePBRMaterialType.Add("BaseColor_Color_B", 1.0f);
+	m_basePBRMaterialType.Add("BaseColor_Factor", 0.0f);
+	m_basePBRMaterialType.Add("BaseColor_UseTexture", true);
+
+	m_basePBRMaterialType.Add("Occlusion_Factor", 0.0f);
+	m_basePBRMaterialType.Add("Occlusion_UseTexture", true);
+
+	m_basePBRMaterialType.Add("Roughness_Factor", 0.9f);
+	m_basePBRMaterialType.Add("Roughness_UseTexture", true);
+
+	m_basePBRMaterialType.Add("Metallic_Factor", 0.1f);
+	m_basePBRMaterialType.Add("Metallic_UseTexture", true);
+
+	m_basePBRMaterialType.Add("Normal_UseTexture", true);
+
+	m_basePBRMaterialType.Add("General_EnableDirectionalLights", true);
+	m_basePBRMaterialType.Add("General_EnablePunctualLights", true);
+	m_basePBRMaterialType.Add("General_EnableAreaLights", false);
+	m_basePBRMaterialType.Add("General_EnableIBL", true);
 }
 
-std::optional<TextureID> MaterialImpl::GetTextureID(MaterialTextureType textureType) const
+void MaterialImpl::SetTextureID(MaterialPropretyGroup propretyGroup, TextureID textureID)
 {
-	TextureIDMap::const_iterator itTexture = m_textureIDs.find(textureType);
-	if(itTexture != m_textureIDs.end())
-	{
-		return itTexture->second;
-	}
+	m_basePBRMaterialType.Add(GetMaterialPropretyTextureKey(propretyGroup), textureID.Data());
+}
 
-	return std::nullopt;
+std::optional<TextureID> MaterialImpl::GetTextureID(MaterialPropretyGroup propretyGroup) const
+{
+	static_assert(sizeof(TextureID) == sizeof(uint32_t));
+	const auto textureID = m_basePBRMaterialType.Get<uint32_t>(GetMaterialPropretyTextureKey(propretyGroup));
+	if (textureID.has_value())
+	{
+		return TextureID(textureID.value());
+	}
+	else
+	{
+		return std::nullopt;
+	}
+}
+
+bool MaterialImpl::IsTextureTypeSetup(MaterialPropretyGroup propretyGroup) const
+{
+	return m_basePBRMaterialType.Exist(GetMaterialPropretyTextureKey(propretyGroup));
 }
 
 }

--- a/private/Scene/MaterialImpl.h
+++ b/private/Scene/MaterialImpl.h
@@ -50,8 +50,8 @@ public:
 		inputArchive >> materialID >> materialName;
 		Init(MaterialID(materialID), MoveTemp(materialName));
 
-		uint64_t stringCount, byte4Count, byte8Count;
-		inputArchive >> stringCount >> byte4Count >> byte8Count;
+		uint64_t stringCount, byte4Count, byte8Count, byte12Count;
+		inputArchive >> stringCount >> byte4Count >> byte8Count >> byte12Count;
 
 		for (uint64_t index = 0; index < stringCount; ++index)
 		{
@@ -60,7 +60,6 @@ public:
 			inputArchive >> key >> value;
 			m_basePBRMaterialType.Add(key, value);
 		}
-
 		for (uint64_t index = 0; index < byte4Count; ++index)
 		{
 			PropertyMapKeyType key;
@@ -68,11 +67,17 @@ public:
 			inputArchive >> key >> value;
 			m_basePBRMaterialType.Add(key, value);
 		}
-
 		for (uint64_t index = 0; index < byte8Count; ++index)
 		{
 			PropertyMapKeyType key;
 			uint64_t value;
+			inputArchive >> key >> value;
+			m_basePBRMaterialType.Add(key, value);
+		}
+		for (uint64_t index = 0; index < byte12Count; ++index)
+		{
+			PropertyMapKeyType key;
+			cd::Vec3f value;
 			inputArchive >> key >> value;
 			m_basePBRMaterialType.Add(key, value);
 		}
@@ -89,11 +94,13 @@ public:
 		const auto stringProperty       = materailType.GetStringProperty();
 		const auto byte4Property        = materailType.GetByte4Property();
 		const auto byte8Property        = materailType.GetByte8Property();
+		const auto byte12Property       = materailType.GetByte12Property();
 
-		outputArchive << 
+		outputArchive <<
 			static_cast<uint64_t>(stringProperty.size()) <<
 			static_cast<uint64_t>(byte4Property.size()) <<
-			static_cast<uint64_t>(byte8Property.size());
+			static_cast<uint64_t>(byte8Property.size()) <<
+			static_cast<uint64_t>(byte12Property.size());
 		
 		for (const auto &[key, value] : stringProperty)
 		{
@@ -104,6 +111,10 @@ public:
 			outputArchive << key << value;
 		}
 		for (const auto &[key, value] : byte8Property)
+		{
+			outputArchive << key << value;
+		}
+		for (const auto &[key, value] : byte12Property)
 		{
 			outputArchive << key << value;
 		}

--- a/private/Scene/MaterialImpl.h
+++ b/private/Scene/MaterialImpl.h
@@ -45,12 +45,12 @@ public:
 	bool IsTextureSetup(MaterialPropertyGroup propertyGroup) const;
 
 	template<typename T>
-	void AddProperty(MaterialPropertyGroup propertyGroup, MaterialProperty property, T value)
+	void AddProperty(MaterialPropertyGroup propertyGroup, MaterialProperty property, const T &value)
 	{
 		m_propertyGroups.Add(GetMaterialPropertyKey(propertyGroup, property), value);
 	}
 	template<typename T>
-	void SetProperty(MaterialPropertyGroup propertyGroup, MaterialProperty property, T value)
+	void SetProperty(MaterialPropertyGroup propertyGroup, MaterialProperty property, const T &value)
 	{
 		m_propertyGroups.Set(GetMaterialPropertyKey(propertyGroup, property), value);
 	}

--- a/private/Scene/MaterialImpl.h
+++ b/private/Scene/MaterialImpl.h
@@ -59,7 +59,7 @@ public:
 	{
 		return m_propertyGroups.Get<T>(GetMaterialPropertyKey(propertyGroup, property));
 	}
-	bool ExtstProperty(MaterialPropertyGroup propertyGroup, MaterialProperty property) const
+	bool ExistProperty(MaterialPropertyGroup propertyGroup, MaterialProperty property) const
 	{
 		return m_propertyGroups.Exist(GetMaterialPropertyKey(propertyGroup, property));
 	}

--- a/public/PropertyMap/PropertyMap.hpp
+++ b/public/PropertyMap/PropertyMap.hpp
@@ -1,23 +1,26 @@
 #pragma once
 
 #include "Math/Vector.hpp"
+#include "Scene/ObjectID.h"
 
 #include <optional>
 #include <cstdint>
 #include <string>
 #include <type_traits>
-#include <unordered_map>
-#include <unordered_set>
+#include <map>
+#include <set>
 #include <vector>
 
 namespace cd
 {
 
+namespace
+{
+using PropertyMapKeyType = std::string;
+}
+
 class PropertyMap final
 {
-public:
-	using KeyType = std::string;
-
 public:
 	PropertyMap() = default;
 	PropertyMap(const PropertyMap &) = delete;
@@ -27,162 +30,133 @@ public:
 	~PropertyMap() = default;
 
 	template<typename T>
-	void Add(const KeyType &key, const T &value);
+	void Add(const PropertyMapKeyType &key, const T &value)
+	{
+		CheckType<T>();
+		if (!Exist(key))
+		{
+			SetValue(key, value);
+			m_keySet.insert(key);
+		}
+		else
+		{
+			printf("PropertyMap key alerady exists!\n");
+		}
+	}
 
 	template<typename T>
-	std::optional<T> Get(const KeyType &key) const;
+	const std::optional<T> Get(const PropertyMapKeyType &key) const
+	{
+		CheckType<T>();
+		if (Exist(key))
+		{
+			if constexpr (std::is_same_v<T, std::string>)
+			{
+				return m_stringProperty.at(key);
+			}
+			else if constexpr (std::is_same_v<T, uint32_t> || std::is_same_v<T, bool> || std::is_same_v<T, int> || std::is_same_v<T, float>)
+			{
+				return reinterpret_cast<const T &>(m_byte4Property.at(key));
+			}
+			else if constexpr (std::is_same_v<T, uint64_t> || std::is_same_v<T, double> || std::is_same_v<T, cd::Vec2f>)
+			{
+				return reinterpret_cast<const T &>(m_byte8Property.at(key));
+			}
+		}
+		else
+		{
+			return std::nullopt;
+		}
+	}
 
 	template<typename T>
-	void Set(const KeyType &key, const T &value);
+	void Set(const PropertyMapKeyType &key, const T &value)
+	{
+		CheckType<T>();
+		if (Exist(key))
+		{
+			SetValue(key, value);
+		}
+		else
+		{
+			printf("PropertyMap key does not exists!\n");
+		}
+	}
 
-	void Remove(const KeyType &key);
+	bool Exist(const PropertyMapKeyType &key) const
+	{
+		return !!m_keySet.count(key);
+	}
+
+	void Remove(const PropertyMapKeyType &key)
+	{
+		if (Exist(key))
+		{
+			m_keySet.erase(key);
+			m_stringProperty.erase(key);
+			m_byte4Property.erase(key);
+			m_byte8Property.erase(key);
+		}
+		else
+		{
+			printf("PropertyMap key does not exists!\n");
+		}
+	}
+
+	void Clear()
+	{
+		m_keySet.clear();
+		m_stringProperty.clear();
+		m_byte4Property.clear();
+		m_byte8Property.clear();
+	}
+
+	const std::map<PropertyMapKeyType, std::string> &GetStringProperty() const { return m_stringProperty; }
+	const std::map<PropertyMapKeyType, uint32_t>    &GetByte4Property() const { return m_byte4Property; }
+	const std::map<PropertyMapKeyType, uint64_t>    &GetByte8Property() const { return m_byte8Property; }
+	const std::set<PropertyMapKeyType>              &GetKeySetProperty() const { return m_keySet; }
 
 private:
 	template<typename T>
-	void SetValue(const KeyType &key, const T &value);
-
-	template<typename T>
-	void CheckType() const;
-
-	bool Exist(const KeyType &key) const;
-
-	std::unordered_map<KeyType, std::string> m_stringProperty;
-	std::unordered_map<KeyType, uint32_t>    m_byte4Property;
-	std::unordered_map<KeyType, uint64_t>    m_byte8Property;
-	std::unordered_map<KeyType, cd::Vec3f>   m_byte12Property;
-	std::unordered_map<KeyType, cd::Vec4f>   m_byte16Property;
-
-	std::unordered_set<KeyType> m_keySet;
-};
-
-template<typename T>
-void PropertyMap::Add(const KeyType &key, const T &value)
-{
-	CheckType<T>();
-	if (!Exist(key))
-	{
-		SetValue(key, value);
-		m_keySet.insert(key);
-	}
-	else
-	{
-		printf("PropertyMap key alerady exists!\n");
-	}
-}
-
-template<typename T>
-std::optional<T> PropertyMap::Get(const KeyType &key) const
-{
-	CheckType<T>();
-	if (Exist(key))
+	void SetValue(const PropertyMapKeyType &key, const T &value)
 	{
 		if constexpr (std::is_same_v<T, std::string>)
 		{
-			return m_stringProperty.at(key);
+			m_stringProperty[key] = value;
 		}
 		else if constexpr (std::is_same_v<T, uint32_t> || std::is_same_v<T, bool> || std::is_same_v<T, int> || std::is_same_v<T, float>)
 		{
-			return reinterpret_cast<const T &>(m_byte4Property.at(key));
+			m_byte4Property[key] = reinterpret_cast<const uint32_t &>(value);
 		}
 		else if constexpr (std::is_same_v<T, uint64_t> || std::is_same_v<T, double> || std::is_same_v<T, cd::Vec2f>)
 		{
-			return reinterpret_cast<const T &>(m_byte8Property.at(key));
-		}
-		else if constexpr (std::is_same_v<T, cd::Vec3f>)
-		{
-			return m_byte12Property.at(key);
-		}
-		else if constexpr (std::is_same_v<T, cd::Vec4f>)
-		{
-			return m_byte16Property.at(key);
+			m_byte8Property[key] = reinterpret_cast<const uint64_t &>(value);
 		}
 	}
-	else
-	{
-		printf("PropertyMap key does not exists!\n");
-		return std::nullopt;
-	}
-}
 
-template<typename T>
-void PropertyMap::Set(const KeyType &key, const T &value)
-{
-	CheckType<T>();
-	if (Exist(key))
+	template<typename T>
+	void CheckType() const
 	{
-		SetValue(key, value);
+		static_assert((
+			std::is_same_v<T, std::string> ||
+			std::is_same_v<T, uint32_t> ||
+			std::is_same_v<T, bool> ||
+			std::is_same_v<T, int> ||
+			std::is_same_v<T, float> ||
+			std::is_same_v<T, double> ||
+			std::is_same_v<T, uint64_t> ||
+			std::is_same_v<T, double> ||
+			std::is_same_v<T, cd::Vec2f>) &&
+			"PropertyMap unsupport type!"
+		);
 	}
-	else
-	{
-		printf("PropertyMap key does not exists!\n");
-	}
-}
 
-void PropertyMap::Remove(const KeyType &key)
-{
-	if (Exist(key))
-	{
-		m_keySet.erase(key);
-		m_stringProperty.erase(key);
-		m_byte4Property.erase(key);
-		m_byte8Property.erase(key);
-		m_byte12Property.erase(key);
-		m_byte16Property.erase(key);
-	}
-	else
-	{
-		printf("PropertyMap key does not exists!\n");
-	}
-}
+	std::map<PropertyMapKeyType, std::string> m_stringProperty;
+	std::map<PropertyMapKeyType, uint32_t>    m_byte4Property;
+	std::map<PropertyMapKeyType, uint64_t>    m_byte8Property;
 
-template<typename T>
-void PropertyMap::SetValue(const KeyType &key, const T &value)
-{
-	if constexpr (std::is_same_v<T, std::string>)
-	{
-		m_stringProperty[key] = value;
-	}
-	else if constexpr (std::is_same_v<T, uint32_t> || std::is_same_v<T, bool> || std::is_same_v<T, int> || std::is_same_v<T, float>)
-	{
-		m_byte4Property[key] = reinterpret_cast<const uint32_t &>(value);
-	}
-	else if constexpr (std::is_same_v<T, uint64_t> || std::is_same_v<T, double> || std::is_same_v<T, cd::Vec2f>)
-	{
-		m_byte8Property[key] = reinterpret_cast<const uint64_t &>(value);
-	}
-	else if constexpr (std::is_same_v<T, cd::Vec3f>)
-	{
-		m_byte12Property[key] = value;
-	}
-	else if constexpr (std::is_same_v<T, cd::Vec4f>)
-	{
-		m_byte16Property[key] = value;
-	}
-}
-
-bool PropertyMap::Exist(const KeyType &key) const
-{
-	return !!m_keySet.count(key);
-}
-
-template<typename T>
-void PropertyMap::CheckType() const
-{
-	static_assert((
-		std::is_same_v<T, std::string> ||
-		std::is_same_v<T, uint32_t> ||
-		std::is_same_v<T, bool> ||
-		std::is_same_v<T, int> ||
-		std::is_same_v<T, float> ||
-		std::is_same_v<T, double> ||
-		std::is_same_v<T, uint64_t> ||
-		std::is_same_v<T, double> ||
-		std::is_same_v<T, cd::Vec2f> ||
-		std::is_same_v<T, cd::Vec3f> ||
-		std::is_same_v<T, cd::Vec4f>) &&
-		"PropertyMap unsupport type!"
-	);
-}
+	std::set<PropertyMapKeyType> m_keySet;
+};
 
 static_assert(sizeof(int) == sizeof(uint32_t));
 static_assert(sizeof(float) == sizeof(uint32_t));

--- a/public/PropertyMap/PropertyMap.hpp
+++ b/public/PropertyMap/PropertyMap.hpp
@@ -11,11 +11,9 @@
 #include <set>
 #include <vector>
 
-namespace cd
-{
+namespace cd {
 
-namespace
-{
+namespace {
 using PropertyMapKeyType = std::string;
 }
 
@@ -62,6 +60,10 @@ public:
 			{
 				return reinterpret_cast<const T &>(m_byte8Property.at(key));
 			}
+			else if constexpr (std::is_same_v<T, cd::Vec3f>)
+			{
+				return m_byte12Property.at(key);
+			}
 		}
 		else
 		{
@@ -96,6 +98,7 @@ public:
 			m_stringProperty.erase(key);
 			m_byte4Property.erase(key);
 			m_byte8Property.erase(key);
+			m_byte12Property.erase(key);
 		}
 		else
 		{
@@ -109,12 +112,14 @@ public:
 		m_stringProperty.clear();
 		m_byte4Property.clear();
 		m_byte8Property.clear();
+		m_byte12Property.clear();
 	}
 
 	const std::map<PropertyMapKeyType, std::string> &GetStringProperty() const { return m_stringProperty; }
-	const std::map<PropertyMapKeyType, uint32_t>    &GetByte4Property() const { return m_byte4Property; }
-	const std::map<PropertyMapKeyType, uint64_t>    &GetByte8Property() const { return m_byte8Property; }
-	const std::set<PropertyMapKeyType>              &GetKeySetProperty() const { return m_keySet; }
+	const std::map<PropertyMapKeyType, uint32_t> &GetByte4Property() const { return m_byte4Property; }
+	const std::map<PropertyMapKeyType, uint64_t> &GetByte8Property() const { return m_byte8Property; }
+	const std::map<PropertyMapKeyType, cd::Vec3f> &GetByte12Property() const { return m_byte12Property; }
+	const std::set<PropertyMapKeyType> &GetKeySetProperty() const { return m_keySet; }
 
 private:
 	template<typename T>
@@ -132,6 +137,10 @@ private:
 		{
 			m_byte8Property[key] = reinterpret_cast<const uint64_t &>(value);
 		}
+		else if constexpr (std::is_same_v<T, cd::Vec3f>)
+		{
+			m_byte12Property[key] = value;
+		}
 	}
 
 	template<typename T>
@@ -146,14 +155,16 @@ private:
 			std::is_same_v<T, double> ||
 			std::is_same_v<T, uint64_t> ||
 			std::is_same_v<T, double> ||
-			std::is_same_v<T, cd::Vec2f>) &&
+			std::is_same_v<T, cd::Vec2f> ||
+			std::is_same_v<T, cd::Vec3f>) &&
 			"PropertyMap unsupport type!"
-		);
+			);
 	}
 
 	std::map<PropertyMapKeyType, std::string> m_stringProperty;
 	std::map<PropertyMapKeyType, uint32_t>    m_byte4Property;
 	std::map<PropertyMapKeyType, uint64_t>    m_byte8Property;
+	std::map<PropertyMapKeyType, cd::Vec3f>   m_byte12Property;
 
 	std::set<PropertyMapKeyType> m_keySet;
 };

--- a/public/PropertyMap/PropertyMap.hpp
+++ b/public/PropertyMap/PropertyMap.hpp
@@ -43,6 +43,20 @@ public:
 	}
 
 	template<typename T>
+	void Set(const PropertyMapKeyType &key, const T &value)
+	{
+		CheckType<T>();
+		if (Exist(key))
+		{
+			SetValue(key, value);
+		}
+		else
+		{
+			printf("PropertyMap key does not exists!\n");
+		}
+	}
+
+	template<typename T>
 	const std::optional<T> Get(const PropertyMapKeyType &key) const
 	{
 		CheckType<T>();
@@ -68,20 +82,6 @@ public:
 		else
 		{
 			return std::nullopt;
-		}
-	}
-
-	template<typename T>
-	void Set(const PropertyMapKeyType &key, const T &value)
-	{
-		CheckType<T>();
-		if (Exist(key))
-		{
-			SetValue(key, value);
-		}
-		else
-		{
-			printf("PropertyMap key does not exists!\n");
 		}
 	}
 

--- a/public/Scene/Material.h
+++ b/public/Scene/Material.h
@@ -22,21 +22,21 @@ public:
 	Material() = delete;
 	explicit Material(InputArchive& inputArchive);
 	explicit Material(InputArchiveSwapBytes& inputArchive);
-	explicit Material(MaterialID materialID, const char* pMaterialName);
+	explicit Material(MaterialID materialID, const char* pMaterialName, MaterialType type);
 	Material(const Material&) = delete;
 	Material& operator=(const Material&) = delete;
 	Material(Material&&);
 	Material& operator=(Material&&);
 	~Material();
 
-	void Init(MaterialID materialID, const char* pMaterialName);
+	void Init(MaterialID materialID, const char* pMaterialName, MaterialType type);
 
 	const MaterialID& GetID() const;
 	const char* GetName() const;
-	void SetTextureID(MaterialPropretyGroup textureType, TextureID textureID);
-	std::optional<TextureID> GetTextureID(MaterialPropretyGroup textureType) const;
-	const PropertyMap& GetMaterialType() const;
-	bool IsTextureTypeSetup(MaterialPropretyGroup textureType) const;
+	void AddTextureID(MaterialPropertyGroup textureType, TextureID textureID);
+	std::optional<TextureID> GetTextureID(MaterialPropertyGroup textureType) const;
+	const PropertyMap &GetPropertyGroups() const;
+	bool IsTextureSetup(MaterialPropertyGroup textureType) const;
 
 	Material& operator<<(InputArchive& inputArchive);
 	Material& operator<<(InputArchiveSwapBytes& inputArchive);

--- a/public/Scene/Material.h
+++ b/public/Scene/Material.h
@@ -5,6 +5,7 @@
 #include "IO/OutputArchive.hpp"
 #include "MaterialTextureType.h"
 #include "Math/Vector.hpp"
+#include "PropertyMap/PropertyMap.hpp"
 #include "Scene/ObjectID.h"
 
 #include <map>
@@ -17,9 +18,6 @@ class MaterialImpl;
 
 class CORE_API Material final
 {
-public:
-	using TextureIDMap = std::map<MaterialTextureType, TextureID>;
-
 public:
 	Material() = delete;
 	explicit Material(InputArchive& inputArchive);
@@ -35,10 +33,10 @@ public:
 
 	const MaterialID& GetID() const;
 	const char* GetName() const;
-	void SetTextureID(MaterialTextureType textureType, TextureID textureID);
-	std::optional<TextureID> GetTextureID(MaterialTextureType textureType) const;
-	const TextureIDMap& GetTextureIDMap() const;
-	bool IsTextureTypeSetup(MaterialTextureType textureType) const;
+	void SetTextureID(MaterialPropretyGroup textureType, TextureID textureID);
+	std::optional<TextureID> GetTextureID(MaterialPropretyGroup textureType) const;
+	const PropertyMap& GetMaterialType() const;
+	bool IsTextureTypeSetup(MaterialPropretyGroup textureType) const;
 
 	Material& operator<<(InputArchive& inputArchive);
 	Material& operator<<(InputArchiveSwapBytes& inputArchive);

--- a/public/Scene/MaterialTextureType.h
+++ b/public/Scene/MaterialTextureType.h
@@ -21,7 +21,7 @@ constexpr const char *MaterialTypeName[] =
 static_assert(static_cast<int>(MaterialType::Count) == sizeof(MaterialTypeName) / sizeof(char *),
 	"Material type and names mismatch.");
 
-inline const char *GetMaterialTypeName(MaterialType materialType)
+CD_FORCEINLINE const char *GetMaterialTypeName(MaterialType materialType)
 {
 	return MaterialTypeName[static_cast<size_t>(materialType)];
 }
@@ -58,7 +58,7 @@ constexpr const char *MaterialPropertyGroupName[] =
 static_assert(static_cast<int>(MaterialPropertyGroup::Count) == sizeof(MaterialPropertyGroupName) / sizeof(char *),
 	"Material property group and names mismatch.");
 
-inline const char *GetMaterialPropertyGroupName(MaterialPropertyGroup propertyGroup) {
+CD_FORCEINLINE const char *GetMaterialPropertyGroupName(MaterialPropertyGroup propertyGroup) {
 	return MaterialPropertyGroupName[static_cast<size_t>(propertyGroup)];
 }
 
@@ -99,11 +99,11 @@ constexpr const char *MaterialPropertyName[] =
 static_assert(static_cast<int>(MaterialProperty::Count) == sizeof(MaterialPropertyName) / sizeof(char *),
 	"Material property and names mismatch.");
 
-inline const char *GetMaterialPropertyName(MaterialProperty property) {
+CD_FORCEINLINE const char *GetMaterialPropertyName(MaterialProperty property) {
 	return MaterialPropertyName[static_cast<size_t>(property)];
 }
 
-inline std::string GetMaterialPropertyKey(MaterialPropertyGroup propertyGroup, MaterialProperty property)
+CD_FORCEINLINE std::string GetMaterialPropertyKey(MaterialPropertyGroup propertyGroup, MaterialProperty property)
 {
 	std::stringstream ss;
 	ss << GetMaterialPropertyGroupName(propertyGroup) << "_" << GetMaterialPropertyName(property);
@@ -111,7 +111,7 @@ inline std::string GetMaterialPropertyKey(MaterialPropertyGroup propertyGroup, M
 	return ss.str();
 }
 
-inline std::string GetMaterialPropertyTextureKey(MaterialPropertyGroup propertyGroup)
+CD_FORCEINLINE std::string GetMaterialPropertyTextureKey(MaterialPropertyGroup propertyGroup)
 {
 	return GetMaterialPropertyKey(propertyGroup, MaterialProperty::Texture);
 }

--- a/public/Scene/MaterialTextureType.h
+++ b/public/Scene/MaterialTextureType.h
@@ -6,7 +6,27 @@
 namespace cd
 {
 
-enum class MaterialPropretyGroup
+enum class MaterialType : uint8_t
+{
+	BasePBR = 0,
+	
+	Count,
+};
+
+constexpr const char *MaterialTypeName[] =
+{
+	"BasePBR",
+};
+
+static_assert(static_cast<int>(MaterialType::Count) == sizeof(MaterialTypeName) / sizeof(char *),
+	"Material type and names mismatch.");
+
+inline const char *GetMaterialTypeName(MaterialType materialType)
+{
+	return MaterialTypeName[static_cast<size_t>(materialType)];
+}
+
+enum class MaterialPropertyGroup
 {
 	BaseColor = 0,
 	Occlusion,
@@ -15,12 +35,16 @@ enum class MaterialPropretyGroup
 	Normal,
 	Emissive,
 	General,
+
 	Count,
 };
 
-using MaterialTextureType = MaterialPropretyGroup;
+// As each MaterialPropertyGroup just has one texture,
+// it's fine to consider MaterialPropertyGroup as MaterialTextureType
+// from the perspective of texture.
+using MaterialTextureType = MaterialPropertyGroup;
 
-constexpr const char *MaterialPropretyGroupName[] =
+constexpr const char *MaterialPropertyGroupName[] =
 {
 	"BaseColor",
 	"Occlusion",
@@ -31,24 +55,24 @@ constexpr const char *MaterialPropretyGroupName[] =
 	"General",
 };
 
-static_assert(static_cast<int>(MaterialPropretyGroup::Count) == sizeof(MaterialPropretyGroupName) / sizeof(char *),
-	"Material proprety group and names mismatch.");
+static_assert(static_cast<int>(MaterialPropertyGroup::Count) == sizeof(MaterialPropertyGroupName) / sizeof(char *),
+	"Material property group and names mismatch.");
 
-inline const char *GetMaterialPropretyGroupName(MaterialPropretyGroup propretyGroup) {
-	return MaterialPropretyGroupName[static_cast<size_t>(propretyGroup)];
+inline const char *GetMaterialPropertyGroupName(MaterialPropertyGroup propertyGroup) {
+	return MaterialPropertyGroupName[static_cast<size_t>(propertyGroup)];
 }
 
 enum class MaterialProperty
 {
 	Name = 0,
+
+	// For BaseColor, Occlusion, Roughness, Metallic and Normal
 	Factor,
 	Texture,
 	UseTexture,
 
 	// Just for BaseColor
-	Color_R,
-	Color_G,
-	Color_B,
+	Color,
 
 	// Just for General Settings
 	EnableDirectionalLights,
@@ -59,39 +83,37 @@ enum class MaterialProperty
 	Count,
 };
 
-constexpr const char *MaterialPropretyName[] =
+constexpr const char *MaterialPropertyName[] =
 {
 	"Name",
 	"Factor",
 	"Texture",
 	"UseTexture",
-	"Color_R",
-	"Color_G",
-	"Color_B",
+	"Color",
 	"EnableDirectionalLights",
 	"EnablePunctualLights",
 	"EnableAreaLights",
 	"EnableIBL",
 };
 
-static_assert(static_cast<int>(MaterialProperty::Count) == sizeof(MaterialPropretyName) / sizeof(char *),
-	"Material proprety and names mismatch.");
+static_assert(static_cast<int>(MaterialProperty::Count) == sizeof(MaterialPropertyName) / sizeof(char *),
+	"Material property and names mismatch.");
 
-inline const char *GetMaterialPropretyName(MaterialProperty proprety) {
-	return MaterialPropretyName[static_cast<size_t>(proprety)];
+inline const char *GetMaterialPropertyName(MaterialProperty property) {
+	return MaterialPropertyName[static_cast<size_t>(property)];
 }
 
-inline std::string GetMaterialPropretyKey(MaterialPropretyGroup propretyGroup, MaterialProperty property)
+inline std::string GetMaterialPropertyKey(MaterialPropertyGroup propertyGroup, MaterialProperty property)
 {
 	std::stringstream ss;
-	ss << GetMaterialPropretyGroupName(propretyGroup) << "_" << GetMaterialPropretyName(property);
+	ss << GetMaterialPropertyGroupName(propertyGroup) << "_" << GetMaterialPropertyName(property);
 
 	return ss.str();
 }
 
-inline std::string GetMaterialPropretyTextureKey(MaterialPropretyGroup propretyGroup)
+inline std::string GetMaterialPropertyTextureKey(MaterialPropertyGroup propertyGroup)
 {
-	return GetMaterialPropretyKey(propretyGroup, MaterialProperty::Texture);
+	return GetMaterialPropertyKey(propertyGroup, MaterialProperty::Texture);
 }
 
 }

--- a/public/Scene/MaterialTextureType.h
+++ b/public/Scene/MaterialTextureType.h
@@ -1,38 +1,97 @@
 #pragma once
 
 #include <cstdint>
+#include <sstream>
 
 namespace cd
 {
 
-enum class MaterialTextureType : uint8_t
+enum class MaterialPropretyGroup
 {
 	BaseColor = 0,
-	Normal,
-	Metalness,
+	Occlusion,
 	Roughness,
+	Metallic,
+	Normal,
 	Emissive,
-	AO,
-	Count
+	General,
+	Count,
 };
 
-constexpr const char* MaterialTextureTypeName[] =
+using MaterialTextureType = MaterialPropretyGroup;
+
+constexpr const char *MaterialPropretyGroupName[] =
 {
 	"BaseColor",
-	"Normal",
-	"Metalness",
+	"Occlusion",
 	"Roughness",
+	"Metallic",
+	"Normal",
 	"Emissive",
-	"AO",
+	"General",
 };
 
-// Sanity check for enum and name mapping.
-static_assert(static_cast<int>(MaterialTextureType::Count) == sizeof(MaterialTextureTypeName) / sizeof(char*),
-	"Material texture types and names mismatch.");
+static_assert(static_cast<int>(MaterialPropretyGroup::Count) == sizeof(MaterialPropretyGroupName) / sizeof(char *),
+	"Material proprety group and names mismatch.");
 
-inline const char* GetMaterialTextureTypeName(MaterialTextureType textureType)
+inline const char *GetMaterialPropretyGroupName(MaterialPropretyGroup propretyGroup) {
+	return MaterialPropretyGroupName[static_cast<size_t>(propretyGroup)];
+}
+
+enum class MaterialProperty
 {
-	return MaterialTextureTypeName[static_cast<int>(textureType)];
+	Name = 0,
+	Factor,
+	Texture,
+	UseTexture,
+
+	// Just for BaseColor
+	Color_R,
+	Color_G,
+	Color_B,
+
+	// Just for General Settings
+	EnableDirectionalLights,
+	EnablePunctualLights,
+	EnableAreaLights,
+	EnableIBL,
+
+	Count,
+};
+
+constexpr const char *MaterialPropretyName[] =
+{
+	"Name",
+	"Factor",
+	"Texture",
+	"UseTexture",
+	"Color_R",
+	"Color_G",
+	"Color_B",
+	"EnableDirectionalLights",
+	"EnablePunctualLights",
+	"EnableAreaLights",
+	"EnableIBL",
+};
+
+static_assert(static_cast<int>(MaterialProperty::Count) == sizeof(MaterialPropretyName) / sizeof(char *),
+	"Material proprety and names mismatch.");
+
+inline const char *GetMaterialPropretyName(MaterialProperty proprety) {
+	return MaterialPropretyName[static_cast<size_t>(proprety)];
+}
+
+inline std::string GetMaterialPropretyKey(MaterialPropretyGroup propretyGroup, MaterialProperty property)
+{
+	std::stringstream ss;
+	ss << GetMaterialPropretyGroupName(propretyGroup) << "_" << GetMaterialPropretyName(property);
+
+	return ss.str();
+}
+
+inline std::string GetMaterialPropretyTextureKey(MaterialPropretyGroup propretyGroup)
+{
+	return GetMaterialPropretyKey(propretyGroup, MaterialProperty::Texture);
 }
 
 }


### PR DESCRIPTION
Refer to #112 
# Abstract Material Hierarchy
- MaterialType
  - MaterialPropertyGroup
    - MaterialProperty

For example:
- BasePBR
  - BaseColor
    - Color
    - Factor
    - Texture
  - Normal
    - Factor
    - Texture
  - ...

# Actual Data Structure
- SceneDatabase
  - Material
    - MaterialType
    - **PropertyMap**
  - Materila
  - ...

# PropertyMap
A key-value map to store variant properties.
- Key is a combination of MaterialPropertyGroup and MaterialProperty,
  which format is `MaterialPropertyGroup_MaterialProperty`.
- Value is the real data of this MaterialType->MaterialPropertyGroup->MaterialProperty hierarchy.

# TODO
Need to apply these changes and test on Engine side.