### PR TITLE
Fixed TerrainProducer to allow editor to produce and render terrain

### DIFF
--- a/private/Producers/TerrainProducer/TerrainProducerImpl.h
+++ b/private/Producers/TerrainProducer/TerrainProducerImpl.h
@@ -82,7 +82,7 @@ private:
 	void GenerateElevationMap(std::vector<int32_t>& outElevationMap, uint32_t sector_x, uint32_t sector_z) const;
 	void GenerateAllSectors(cd::SceneDatabase* pSceneDatabase);
 	cd::Mesh GenerateSectorAt(uint32_t sector_x, uint32_t sector_z, const std::vector<int32_t>& elevationMap);
-	void GenerateMaterialAndTextures(cd::SceneDatabase* pSceneDatabase, uint32_t sector_x, uint32_t sector_z, std::vector<int32_t>& elevationMap);
+	cd::MaterialID GenerateMaterialAndTextures(cd::SceneDatabase* pSceneDatabase, uint32_t sector_x, uint32_t sector_z, std::vector<int32_t>& elevationMap);
 };
 
 }	// namespace cdtools

--- a/private/Scene/SceneDatabaseImpl.cpp
+++ b/private/Scene/SceneDatabaseImpl.cpp
@@ -15,6 +15,16 @@ SceneDatabaseImpl::SceneDatabaseImpl()
 ///////////////////////////////////////////////////////////////////
 // Node
 ///////////////////////////////////////////////////////////////////
+void SceneDatabaseImpl::SetNodeCount(uint32_t nodeCount)
+{
+	m_nodes.reserve(nodeCount);
+}
+
+void SceneDatabaseImpl::AddNode(Node node)
+{
+	m_nodes.emplace_back(MoveTemp(node));
+}
+
 const Node* SceneDatabaseImpl::GetNodeByName(const std::string& name) const
 {
 	for (const auto& node : m_nodes)
@@ -31,6 +41,16 @@ const Node* SceneDatabaseImpl::GetNodeByName(const std::string& name) const
 ///////////////////////////////////////////////////////////////////
 // Bone
 ///////////////////////////////////////////////////////////////////
+void SceneDatabaseImpl::SetBoneCount(uint32_t boneCount)
+{
+	m_bones.reserve(boneCount);
+}
+
+void SceneDatabaseImpl::AddBone(Bone bone)
+{
+	m_bones.emplace_back(MoveTemp(bone));
+}
+
 const Bone* SceneDatabaseImpl::GetBoneByName(const std::string& name) const
 {
 	for (const auto& bone : m_bones)
@@ -42,6 +62,67 @@ const Bone* SceneDatabaseImpl::GetBoneByName(const std::string& name) const
 	}
 
 	return nullptr;
+}
+
+///////////////////////////////////////////////////////////////////
+// Mesh
+///////////////////////////////////////////////////////////////////
+void SceneDatabaseImpl::SetMeshCount(uint32_t meshCount)
+{
+	m_meshes.reserve(meshCount);
+}
+
+void SceneDatabaseImpl::AddMesh(Mesh mesh)
+{
+	m_meshes.emplace_back(MoveTemp(mesh));
+}
+
+///////////////////////////////////////////////////////////////////
+// Material
+///////////////////////////////////////////////////////////////////
+void SceneDatabaseImpl::SetMaterialCount(uint32_t materialCount)
+{
+	m_materials.reserve(materialCount);
+}
+
+void SceneDatabaseImpl::AddMaterial(Material material)
+{
+	m_materials.emplace_back(MoveTemp(material));
+}
+
+///////////////////////////////////////////////////////////////////
+// Texture
+///////////////////////////////////////////////////////////////////
+void SceneDatabaseImpl::SetTextureCount(uint32_t textureCount)
+{
+	m_textures.reserve(textureCount);
+}
+
+void SceneDatabaseImpl::AddTexture(Texture texture)
+{
+	// ID needs to match the index here
+	if (texture.GetID().Data() == m_textures.size())
+	{
+		m_textures.emplace_back(MoveTemp(texture));
+	}
+	else
+	{
+		// Check if we are trying to add something that already exist!
+		assert(m_textures[texture.GetID().Data()].GetID().Data() == texture.GetID().Data());
+	}
+}
+
+///////////////////////////////////////////////////////////////////
+// Light
+///////////////////////////////////////////////////////////////////
+void SceneDatabaseImpl::SetLightCount(uint32_t lightCount)
+{
+	m_lights.reserve(lightCount);
+}
+
+void SceneDatabaseImpl::AddLight(Light light)
+{
+	m_lights.emplace_back(MoveTemp(light));
 }
 
 }

--- a/private/Scene/Texture.cpp
+++ b/private/Scene/Texture.cpp
@@ -44,14 +44,18 @@ void Texture::Init(TextureID textureID, MaterialTextureType textureType, const c
     m_pTextureImpl->Init(textureID, textureType, pTexturePath);
 }
 
-void Texture::SetRawTexture(const std::vector<int32_t>& inputData, const cd::TextureFormat format)
+void Texture::SetRawTexture(const std::vector<int32_t>& inputData, const cd::TextureFormat format, uint32_t width, uint32_t height)
 {
-    m_pTextureImpl->SetRawTexture(inputData, format);
+    m_pTextureImpl->SetRawTexture(inputData, format, width, height);
 }
 
 void Texture::ClearRawTexture()
 {
     m_pTextureImpl->ClearRawTexture();
+}
+
+bool Texture::HasRawTexture() const {
+    return m_pTextureImpl->HasRawTexture();
 }
 
 const TextureID& Texture::GetID() const
@@ -77,6 +81,14 @@ const cd::TextureFormat Texture::GetTextureFormat() const
 const std::vector<std::byte>& Texture::GetRawTexture() const
 {
     return m_pTextureImpl->GetRawTexture();
+}
+
+uint32_t Texture::GetWidth() const {
+    return m_pTextureImpl->GetWidth();
+}
+
+uint32_t Texture::GetHeight() const {
+    return m_pTextureImpl->GetHeight();
 }
 
 Texture& Texture::operator<<(InputArchive& inputArchive)

--- a/private/Scene/TextureImpl.cpp
+++ b/private/Scene/TextureImpl.cpp
@@ -6,6 +6,8 @@ namespace cd
 TextureImpl::TextureImpl(TextureID textureID, MaterialTextureType textureType, std::string texturePath)
 	: m_textureFormat(TextureFormat::Count)
 	, m_rawTexture()
+	, m_textureWidth(0)
+	, m_textureHeight(0)
 {
 	Init(textureID, textureType, MoveTemp(texturePath));
 }
@@ -14,6 +16,8 @@ void TextureImpl::ClearRawTexture()
 {
 	m_textureFormat = TextureFormat::Count;
 	m_rawTexture.clear();
+	m_textureWidth = 0;
+	m_textureHeight = 0;
 }
 
 void TextureImpl::Init(TextureID textureID, MaterialTextureType textureType, std::string texturePath)

--- a/private/Scene/TextureImpl.h
+++ b/private/Scene/TextureImpl.h
@@ -32,20 +32,25 @@ public:
 	void Init(TextureID textureID, MaterialTextureType textureType, std::string texturePath);
 
 	template <typename T>
-	void SetRawTexture(const std::vector<T>& inputData, const cd::TextureFormat format) {
+	void SetRawTexture(const std::vector<T>& inputData, const cd::TextureFormat format, const uint32_t width, const uint32_t height) {
 		const size_t sizeRatio = sizeof(T) / sizeof(std::byte);
 		const size_t sizeInBytes = inputData.size() * sizeRatio;
 		m_rawTexture.resize(sizeInBytes);
 		std::memcpy(m_rawTexture.data(), inputData.data(), sizeInBytes);
 		m_textureFormat = format;
+		m_textureWidth = width;
+		m_textureHeight = height;
 	}
 	void ClearRawTexture();
+	bool HasRawTexture() const { return !m_rawTexture.empty(); }
 
 	const TextureID& GetID() const { return m_id; }
 	cd::MaterialTextureType GetType() const { return m_textureType; }
 	const std::string& GetPath() const { return m_path; }
 	const cd::TextureFormat GetTextureFormat() const { return m_textureFormat; }
 	const std::vector<std::byte>& GetRawTexture() const { return m_rawTexture; }
+	uint32_t GetWidth() const { return m_textureWidth; }
+	uint32_t GetHeight() const { return m_textureHeight; }
 
 	template<bool SwapBytesOrder>
 	TextureImpl& operator<<(TInputArchive<SwapBytesOrder>& inputArchive)
@@ -90,6 +95,8 @@ private:
 	cd::MaterialTextureType m_textureType;
 	std::string m_path;
 	cd::TextureFormat m_textureFormat;
+	uint32_t m_textureWidth;
+	uint32_t m_textureHeight;
 	std::vector<std::byte> m_rawTexture;
 };
 

--- a/public/Scene/Texture.h
+++ b/public/Scene/Texture.h
@@ -29,15 +29,17 @@ public:
 
 	void Init(TextureID textureID, MaterialTextureType textureType, const char* pTexturePath);
 
-	void SetRawTexture(const std::vector<int32_t>& inputData, const cd::TextureFormat format);
-
+	void SetRawTexture(const std::vector<int32_t>& inputData, const cd::TextureFormat format, uint32_t width, uint32_t height);
 	void ClearRawTexture();
+	bool HasRawTexture() const;
 
 	const TextureID& GetID() const;
 	cd::MaterialTextureType GetType() const;
 	const char* GetPath() const;
 	const cd::TextureFormat GetTextureFormat() const;
 	const std::vector<std::byte>& GetRawTexture() const;
+	uint32_t GetWidth() const;
+	uint32_t GetHeight() const;
 
 	Texture& operator<<(InputArchive& inputArchive);
 	Texture& operator<<(InputArchiveSwapBytes& inputArchive);


### PR DESCRIPTION
= Fixed 1-off error for elevation texture generation 
= Fixed TerrainProducer not using the correct string format to generate terrain meshes 
= Fixed TerrainProducer not allocating 1 set of UV 
= Fixed TerrainProducer not adding the generated material ID to the scene (and only added to the Mesh) 
= Fixed TerrainProducer referencing the wrong dirt texture name 
= Added texture width and height that's needed for generated textures (vs textures loaded from files)