### PR TITLE
Fix Terrain texture ID being 0 for base color

### DIFF
--- a/private/Producers/TerrainProducer/TerrainProducerImpl.cpp
+++ b/private/Producers/TerrainProducer/TerrainProducerImpl.cpp
@@ -43,6 +43,8 @@ float GetNoiseAt(
 	return height;
 }
 
+uint32_t kNextTextureId;
+
 }
 
 namespace cdtools
@@ -70,7 +72,7 @@ void TerrainProducerImpl::SetSceneDatabaseIDs(const SceneDatabase* pSceneDatabas
 	m_nodeIDGenerator.SetCurrentID(pSceneDatabase->GetNodeCount());
 	m_meshIDGenerator.SetCurrentID(pSceneDatabase->GetMeshCount());
 	m_materialIDGenerator.SetCurrentID(pSceneDatabase->GetMaterialCount());
-	m_textureIDGenerator.SetCurrentID(pSceneDatabase->GetTextureCount());
+	kNextTextureId = pSceneDatabase->GetTextureCount();
 }
 
 void TerrainProducerImpl::SetTerrainMetadata(const TerrainMetadata& metadata)
@@ -93,6 +95,7 @@ void TerrainProducerImpl::Initialize()
 	m_quadsPerSector = m_sectorMetadata.numQuadsInX * m_sectorMetadata.numQuadsInZ;
 	m_verticesPerSector = m_quadsPerSector * 4;
 	m_trianglesPerSector = m_quadsPerSector * 2;
+	kNextTextureId = 0;
 }
 
 void TerrainProducerImpl::Execute(SceneDatabase* pSceneDatabase)
@@ -223,14 +226,14 @@ MaterialID TerrainProducerImpl::GenerateMaterialAndTextures(cd::SceneDatabase* p
 	// Base color texture
 	std::string textureName = "Terrain_baseColor";
 	TextureID::ValueType textureHash = StringHash<TextureID::ValueType>(textureName);
-	TextureID textureID = m_textureIDGenerator.AllocateID(textureHash);
+	TextureID textureID = TextureID(kNextTextureId++);
 	terrainSectorMaterial.AddTextureID(MaterialTextureType::BaseColor, textureID);
 	pSceneDatabase->AddTexture(Texture(textureID, MaterialTextureType::BaseColor, textureName.c_str()));
 
 	// ElevationMap texture
 	textureName = string_format("TerrainElevationMap(%d, %d)", sector_x, sector_z);
 	textureHash = StringHash<TextureID::ValueType>(textureName);
-	textureID = m_textureIDGenerator.AllocateID(textureHash);
+	textureID = TextureID(kNextTextureId++);
 	terrainSectorMaterial.AddTextureID(MaterialTextureType::Roughness, textureID);
 	Texture elevationTexture = Texture(textureID, MaterialTextureType::Roughness, textureName.c_str());
 	elevationTexture.SetRawTexture(elevationMap, TextureFormat::R32I, m_sectorLenInX + 1, m_sectorLenInZ + 1);

--- a/private/Producers/TerrainProducer/TerrainProducerImpl.h
+++ b/private/Producers/TerrainProducer/TerrainProducerImpl.h
@@ -77,7 +77,6 @@ private:
 	cd::ObjectIDGenerator<cd::NodeID> m_nodeIDGenerator;
 	cd::ObjectIDGenerator<cd::MeshID> m_meshIDGenerator;
 	cd::ObjectIDGenerator<cd::MaterialID> m_materialIDGenerator;
-	cd::ObjectIDGenerator<cd::TextureID> m_textureIDGenerator;
 
 	void GenerateElevationMap(std::vector<int32_t>& outElevationMap, uint32_t sector_x, uint32_t sector_z) const;
 	void GenerateAllSectors(cd::SceneDatabase* pSceneDatabase);


### PR DESCRIPTION
Previous we used the name of texture to generate ID. This won't create continuous index as required by SceneDatabase. This fixes it by simply using a counter. 

![Example](https://user-images.githubusercontent.com/1388148/224611427-79824846-0793-483c-a2cb-a251cc35d49e.png)

