### PR TITLE
Add flatten option for processor

### DIFF
--- a/private/Framework/Processor.cpp
+++ b/private/Framework/Processor.cpp
@@ -18,6 +18,16 @@ Processor::~Processor()
 	}
 }
 
+const cd::SceneDatabase* Processor::GetSceneDatabase() const
+{
+	return m_pProcessorImpl->GetSceneDatabase();
+}
+
+void Processor::Run()
+{
+	m_pProcessorImpl->Run();
+}
+
 void Processor::SetValidateSceneDatabaseEnable(bool enable)
 {
 	m_pProcessorImpl->SetValidateSceneDatabaseEnable(enable);
@@ -38,14 +48,24 @@ bool Processor::IsDumpSceneDatabaseEnabled() const
 	return m_pProcessorImpl->IsDumpSceneDatabaseEnabled();
 }
 
-const cd::SceneDatabase* Processor::GetSceneDatabase() const
+void Processor::SetCalculateAABBForSceneDatabaseEnable(bool enable)
 {
-	return m_pProcessorImpl->GetSceneDatabase();
+	m_pProcessorImpl->SetCalculateAABBForSceneDatabaseEnable(enable);
 }
 
-void Processor::Run()
+bool Processor::IsCalculateAABBForSceneDatabaseEnabled() const
 {
-	m_pProcessorImpl->Run();
+	return m_pProcessorImpl->IsCalculateAABBForSceneDatabaseEnabled();
+}
+
+void Processor::SetFlattenSceneDatabaseEnable(bool enable)
+{
+	m_pProcessorImpl->SetFlattenSceneDatabaseEnable(enable);
+}
+
+bool Processor::IsFlattenSceneDatabaseEnabled() const
+{
+	return m_pProcessorImpl->IsFlattenSceneDatabaseEnabled();
 }
 
 }

--- a/private/Framework/ProcessorImpl.cpp
+++ b/private/Framework/ProcessorImpl.cpp
@@ -20,12 +20,36 @@ void Dump(const char* label, cd::Vec3f vector)
 	printf("%s : (x = %f, y = %f, z = %f)\n", label, vector.x(), vector.y(), vector.z());
 }
 
+void Dump(const char* label, cd::Vec4f vector)
+{
+	printf("%s : (x = %f, y = %f, z = %f, w = %f)\n", label, vector.x(), vector.y(), vector.z(), vector.z());
+}
+
 void Dump(const cd::Transform& transform)
 {
 	details::Dump("\tTranslation", transform.GetTranslation());
 	details::Dump("\tRotation", transform.GetRotation());
 	details::Dump("\tScale", transform.GetScale());
 }
+
+void CalculateNodeTransforms(std::vector<cd::Matrix4x4>& nodeFinalTransforms, const cd::SceneDatabase* pSceneDatabase, const cd::Node& node)
+{
+	// DFS gurantees that parent node's transform will be calculated before child nodes.
+	cd::Matrix4x4 parentTransform = cd::Matrix4x4::Identity();
+	if (node.GetParentID().IsValid())
+	{
+		parentTransform = nodeFinalTransforms[node.GetParentID().Data()];
+	}
+	cd::Matrix4x4 localTransform = node.GetTransform().GetMatrix();
+	nodeFinalTransforms[node.GetID().Data()] = localTransform * parentTransform;
+
+	const std::vector<cd::NodeID>& childIDs = node.GetChildIDs();
+	for (uint32_t childIndex = 0U; childIndex < node.GetChildCount(); ++childIndex)
+	{
+		cd::NodeID childNodeID = childIDs[childIndex];
+		CalculateNodeTransforms(nodeFinalTransforms, pSceneDatabase, pSceneDatabase->GetNode(childNodeID.Data()));
+	}
+};
 
 }
 
@@ -54,6 +78,41 @@ ProcessorImpl::ProcessorImpl(IProducer* pProducer, IConsumer* pConsumer, cd::Sce
 
 ProcessorImpl::~ProcessorImpl()
 {
+}
+
+void ProcessorImpl::Run()
+{
+	m_pProducer->Execute(m_pCurrentSceneDatabase);
+
+	// Take care to keep correct order for post-process steps.
+	if (IsValidateSceneDatabaseEnabled())
+	{
+		// Pre-validation before doing post-process.
+		ValidateSceneDatabase();
+	}
+
+	if (IsFlattenSceneDatabaseEnabled())
+	{
+		FlattenSceneDatabase();
+	}
+
+	if (IsCalculateAABBForSceneDatabaseEnabled())
+	{
+		CalculateAABBForSceneDatabase();
+	}
+
+	if (IsValidateSceneDatabaseEnabled())
+	{
+		// Post-validation after doing post-process.
+		ValidateSceneDatabase();
+	}
+
+	if (IsDumpSceneDatabaseEnabled())
+	{
+		DumpSceneDatabase();
+	}
+
+	m_pConsumer->Execute(m_pCurrentSceneDatabase);
 }
 
 void ProcessorImpl::DumpSceneDatabase()
@@ -288,29 +347,91 @@ void ProcessorImpl::ValidateSceneDatabase()
 
 void ProcessorImpl::CalculateAABBForSceneDatabase()
 {
+	// Update mesh AABB by its current vertex positions.
+	std::vector<cd::Mesh>& meshes = m_pCurrentSceneDatabase->GetMeshes();
+	for (uint32_t meshIndex = 0U; meshIndex < m_pCurrentSceneDatabase->GetMeshCount(); ++meshIndex)
+	{
+		cd::Mesh& mesh = meshes[meshIndex];
+
+		// Apply transform to vertex position.
+		cd::Point minPoint(FLT_MAX);
+		cd::Point maxPoint(-FLT_MAX);
+		for (uint32_t vertexIndex = 0U; vertexIndex < mesh.GetVertexCount(); ++vertexIndex)
+		{
+			const cd::Point& position = mesh.GetVertexPosition(vertexIndex);
+			minPoint.x() = minPoint.x() > position.x() ? position.x() : minPoint.x();
+			minPoint.y() = minPoint.y() > position.y() ? position.y() : minPoint.y();
+			minPoint.z() = minPoint.z() > position.z() ? position.z() : minPoint.z();
+			maxPoint.x() = maxPoint.x() > position.x() ? maxPoint.x() : position.x();
+			maxPoint.y() = maxPoint.y() > position.y() ? maxPoint.y() : position.y();
+			maxPoint.z() = maxPoint.z() > position.z() ? maxPoint.z() : position.z();
+		}
+
+		mesh.SetAABB(cd::AABB(cd::MoveTemp(minPoint), cd::MoveTemp(maxPoint)));
+	}
+
+	// Update scene AABB by meshes' AABB.
 	m_pCurrentSceneDatabase->UpdateAABB();
 }
 
-void ProcessorImpl::Run()
+void ProcessorImpl::FlattenSceneDatabase()
 {
-	m_pProducer->Execute(m_pCurrentSceneDatabase);
-
-	if (IsDumpSceneDatabaseEnabled())
+	uint32_t totalNodeCount = m_pCurrentSceneDatabase->GetNodeCount();
+	if (0U == totalNodeCount)
 	{
-		DumpSceneDatabase();
+		return;
 	}
 
-	if (IsValidateSceneDatabaseEnabled())
+	// Init every node's final transform matrix after removing node hierarchy.
+	std::vector<cd::Matrix4x4> nodeFinalTransforms;
+	nodeFinalTransforms.reserve(totalNodeCount);
+	std::map<uint32_t, uint32_t> mapMeshIDToAssociatedNodeID;
+	for (uint32_t nodeIndex = 0U; nodeIndex < totalNodeCount; ++nodeIndex)
 	{
-		ValidateSceneDatabase();
+		const cd::Node& node = m_pCurrentSceneDatabase->GetNode(nodeIndex);
+		const std::vector<cd::MeshID>& nodeMeshIDs = node.GetMeshIDs();
+		for (uint32_t nodeMeshIndex = 0U; nodeMeshIndex < node.GetMeshCount(); ++nodeMeshIndex)
+		{
+			mapMeshIDToAssociatedNodeID[nodeMeshIDs[nodeMeshIndex].Data()] = nodeIndex;
+		}
+
+		nodeFinalTransforms.push_back(cd::Transform::Identity().GetMatrix());
 	}
 
-	if (IsCalculateAABBForSceneDatabaseEnabled())
+	const cd::Node& rootNode = m_pCurrentSceneDatabase->GetNode(0);
+	details::CalculateNodeTransforms(nodeFinalTransforms, m_pCurrentSceneDatabase, rootNode);
+
+	std::vector<cd::Mesh>& meshes = m_pCurrentSceneDatabase->GetMeshes();
+	for (uint32_t meshIndex = 0U; meshIndex < m_pCurrentSceneDatabase->GetMeshCount(); ++meshIndex)
 	{
-		CalculateAABBForSceneDatabase();
+		cd::Mesh& mesh = meshes[meshIndex];
+		if (0U != mesh.GetVertexInfluenceCount())
+		{
+			// Don't need to support flatten SkinMesh currently.
+			continue;
+		}
+
+		// Apply transform to vertex position.
+		auto itNodeIndex = mapMeshIDToAssociatedNodeID.find(meshIndex);
+		if (itNodeIndex == mapMeshIDToAssociatedNodeID.end())
+		{
+			// If a mesh doesn't find its associated node, no need to process.
+			continue;
+		}
+
+		uint32_t nodeIndex = itNodeIndex->second;
+		const cd::Matrix4x4& finalTransform = nodeFinalTransforms[nodeIndex];
+		for (uint32_t vertexIndex = 0U; vertexIndex < mesh.GetVertexCount(); ++vertexIndex)
+		{
+			const cd::Point& position = mesh.GetVertexPosition(vertexIndex);
+			cd::Vec4f newPosition = finalTransform * cd::Vec4f(position.x(), position.y(), position.z(), 1.0f);
+			mesh.SetVertexPosition(vertexIndex, cd::Point(newPosition.x(), newPosition.y(), newPosition.z()));
+		}
 	}
 
-	m_pConsumer->Execute(m_pCurrentSceneDatabase);
+	// Delete all nodes.
+	m_pCurrentSceneDatabase->GetNodes().clear();
+	m_pCurrentSceneDatabase->SetNodeCount(0U);
 }
 
 }

--- a/private/Framework/ProcessorImpl.cpp
+++ b/private/Framework/ProcessorImpl.cpp
@@ -22,7 +22,7 @@ void Dump(const char* label, cd::Vec3f vector)
 
 void Dump(const char* label, cd::Vec4f vector)
 {
-	printf("%s : (x = %f, y = %f, z = %f, w = %f)\n", label, vector.x(), vector.y(), vector.z(), vector.z());
+	printf("%s : (x = %f, y = %f, z = %f, w = %f)\n", label, vector.x(), vector.y(), vector.z(), vector.w());
 }
 
 void Dump(const cd::Transform& transform)

--- a/private/Framework/ProcessorImpl.h
+++ b/private/Framework/ProcessorImpl.h
@@ -38,10 +38,14 @@ public:
 	void SetCalculateAABBForSceneDatabaseEnable(bool enable) { m_enableCalculateAABBForSceneDatabase = enable; }
 	bool IsCalculateAABBForSceneDatabaseEnabled() const { return m_enableCalculateAABBForSceneDatabase; }
 
+	void SetFlattenSceneDatabaseEnable(bool enable) { m_enableFlattenSceneDatabase = enable; }
+	bool IsFlattenSceneDatabaseEnabled() const { return m_enableFlattenSceneDatabase; }
+
 private:
 	void DumpSceneDatabase();
 	void ValidateSceneDatabase();
 	void CalculateAABBForSceneDatabase();
+	void FlattenSceneDatabase();
 
 private:
 	IProducer* m_pProducer = nullptr;
@@ -53,6 +57,7 @@ private:
 	bool m_enableDumpSceneDatabase = true;
 	bool m_enableValidateSceneDatabase = true;
 	bool m_enableCalculateAABBForSceneDatabase = true;
+	bool m_enableFlattenSceneDatabase = false;
 };
 
 }

--- a/private/Producers/GenericProducer/GenericProducerImpl.cpp
+++ b/private/Producers/GenericProducer/GenericProducerImpl.cpp
@@ -67,27 +67,27 @@ uint32_t GenericProducerImpl::GetImportFlags() const
 	uint32_t importFlags = DefaultImportModelFlags;
 	if (IsTriangulateServiceActive())
 	{
-		importFlags += aiProcess_Triangulate;
+		importFlags |= aiProcess_Triangulate;
 	}
 
 	if (IsBoundingBoxServiceActive())
 	{
-		importFlags += aiProcess_GenBoundingBoxes;
+		importFlags |= aiProcess_GenBoundingBoxes;
 	}
 
 	if (IsFlattenHierarchyServiceActive())
 	{
-		importFlags += aiProcess_PreTransformVertices;
+		importFlags |= aiProcess_PreTransformVertices;
 	}
 
 	if (IsTangentsSpaceServiceActive())
 	{
-		importFlags += aiProcess_CalcTangentSpace;
+		importFlags |= aiProcess_CalcTangentSpace;
 	}
 
 	if (IsImproveACMRServiceActive())
 	{
-		importFlags += aiProcess_ImproveCacheLocality;
+		importFlags |= aiProcess_ImproveCacheLocality;
 	}
 
 	return importFlags;
@@ -135,7 +135,8 @@ cd::MaterialID GenericProducerImpl::AddMaterial(cd::SceneDatabase* pSceneDatabas
 	}
 	else
 	{
-		finalMaterialName = "untitled_" + pSceneDatabase->GetMaterialCount();
+		finalMaterialName = "untitled_";
+		finalMaterialName += std::to_string(pSceneDatabase->GetMaterialCount());
 		printf("\tWarning : current material doesn't have name?\n");
 	}
 

--- a/public/Framework/Processor.h
+++ b/public/Framework/Processor.h
@@ -38,6 +38,11 @@ public:
 	void SetCalculateAABBForSceneDatabaseEnable(bool enable);
 	bool IsCalculateAABBForSceneDatabaseEnabled() const;
 
+	// Flatten objects hierarchy for SceneDatabase.
+	// Currently, we only support to flatten cd::Node and cd::Mesh for static meshes.
+	void SetFlattenSceneDatabaseEnable(bool enable);
+	bool IsFlattenSceneDatabaseEnabled() const;
+
 	const cd::SceneDatabase* GetSceneDatabase() const;
 	void Run();
 


### PR DESCRIPTION
Use `void Processor::SetFlattenSceneDatabaseEnable(bool)` to flatten nodes.
Different with assimp's implementation:
1. Don't break Bone hierarchy.
2. Delete all Nodes including RootNde.
3. Don't apply to Animation and SkinMesh data.