### PR TITLE
fix node invalid pointer

### DIFF
--- a/private/Producers/FbxProducer/FbxProducerImpl.cpp
+++ b/private/Producers/FbxProducer/FbxProducerImpl.cpp
@@ -208,7 +208,7 @@ void FbxProducerImpl::Execute(cd::SceneDatabase* pSceneDatabase)
 		uint32_t oldNodeCount = pSceneDatabase->GetNodeCount();
 		m_nodeIDGenerator.SetCurrentID(oldNodeCount);
 		pSceneDatabase->SetNodeCount(oldNodeCount + sceneNodeCount);
-		TraverseNodeRecursively(pSDKScene->GetRootNode(), nullptr, pSceneDatabase);
+		TraverseNodeRecursively(pSDKScene->GetRootNode(), cd::NodeID::InvalidID, pSceneDatabase);
 	}
 
 	// Convert fbx bone/joint to cd scene bone/joint.
@@ -247,16 +247,14 @@ int FbxProducerImpl::GetSceneNodeCount(const fbxsdk::FbxNode* pSceneNode)
 	return totalCount;
 }
 
-void FbxProducerImpl::TraverseNodeRecursively(fbxsdk::FbxNode* pSDKNode, cd::Node* pParentNode, cd::SceneDatabase* pSceneDatabase)
+void FbxProducerImpl::TraverseNodeRecursively(fbxsdk::FbxNode* pSDKNode, cd::NodeID parentNodeID, cd::SceneDatabase* pSceneDatabase)
 {
 	fbxsdk::FbxNodeAttribute* pNodeAttribute = pSDKNode->GetNodeAttribute();
 
-	cd::Node* pNode = nullptr;
 	if (nullptr == pNodeAttribute ||
 		fbxsdk::FbxNodeAttribute::eNull == pNodeAttribute->GetAttributeType())
 	{
-		cd::NodeID nodeID = AddNode(pSDKNode, pParentNode, pSceneDatabase);
-		pNode = &pSceneDatabase->GetNodes()[nodeID.Data()];
+		AddNode(pSDKNode, parentNodeID, pSceneDatabase);
 	}
 	else if (fbxsdk::FbxNodeAttribute::eLight == pNodeAttribute->GetAttributeType() && m_importLight)
 	{
@@ -300,7 +298,7 @@ void FbxProducerImpl::TraverseNodeRecursively(fbxsdk::FbxNode* pSDKNode, cd::Nod
 				{
 					assert(1U == materialCount && "Material is AllSame mapping mode but has multiple materials.");
 
-					AddMesh(pFbxMesh, pSDKNode->GetName(), 0, pParentNode, pSceneDatabase);
+					AddMesh(pFbxMesh, pSDKNode->GetName(), 0, parentNodeID, pSceneDatabase);
 				}
 				else if (fbxsdk::FbxLayerElement::eByPolygon == materialMappingMode)
 				{
@@ -308,36 +306,36 @@ void FbxProducerImpl::TraverseNodeRecursively(fbxsdk::FbxNode* pSDKNode, cd::Nod
 
 					// It will generate multiple meshes to assign one material.
 					// To manage them conveniently, they are placed under a new Node.
-					cd::NodeID meshesNodeID = AddNode(pSDKNode, pParentNode, pSceneDatabase);
+					cd::NodeID meshesNodeID = AddNode(pSDKNode, parentNodeID, pSceneDatabase);
 					for (uint32_t materialIndex = 0U; materialIndex < materialCount; ++materialIndex)
 					{
 						std::string splitMeshName(std::format("{}_{}", pSDKNode->GetName(), materialIndex));
-						AddMesh(pFbxMesh, splitMeshName.c_str(), materialIndex, &pSceneDatabase->GetNodes()[meshesNodeID.Data()], pSceneDatabase);
+						AddMesh(pFbxMesh, splitMeshName.c_str(), materialIndex, meshesNodeID, pSceneDatabase);
 					}
 				}
 			}
 			else
 			{
-				AddMesh(pFbxMesh, pSDKNode->GetName(), std::nullopt, pParentNode, pSceneDatabase);
+				AddMesh(pFbxMesh, pSDKNode->GetName(), std::nullopt, parentNodeID, pSceneDatabase);
 			}
 		}
 	}
 
 	for (int childIndex = 0; childIndex < pSDKNode->GetChildCount(); ++childIndex)
 	{
-		TraverseNodeRecursively(pSDKNode->GetChild(childIndex), pNode, pSceneDatabase);
+		TraverseNodeRecursively(pSDKNode->GetChild(childIndex), parentNodeID, pSceneDatabase);
 	}
 }
 
-cd::NodeID FbxProducerImpl::AddNode(const fbxsdk::FbxNode* pSDKNode, cd::Node* pParentNode, cd::SceneDatabase* pSceneDatabase)
+cd::NodeID FbxProducerImpl::AddNode(const fbxsdk::FbxNode* pSDKNode, cd::NodeID parentNodeID, cd::SceneDatabase* pSceneDatabase)
 {
 	cd::NodeID nodeID = m_nodeIDGenerator.AllocateID();
 	cd::Node node(nodeID, pSDKNode->GetName());
 	node.SetTransform(details::ConvertFbxNodeTransform(const_cast<fbxsdk::FbxNode*>(pSDKNode)));
-	if (pParentNode)
+	if (parentNodeID.IsValid())
 	{
-		pParentNode->AddChildID(nodeID.Data());
-		node.SetParentID(pParentNode->GetID().Data());
+		pSceneDatabase->GetNode(parentNodeID.Data()).AddChildID(nodeID.Data());
+		node.SetParentID(parentNodeID.Data());
 	}
 	pSceneDatabase->AddNode(cd::MoveTemp(node));
 
@@ -409,7 +407,7 @@ cd::LightID FbxProducerImpl::AddLight(const fbxsdk::FbxLight* pFbxLight, const c
 	return lightID;
 }
 
-cd::MeshID FbxProducerImpl::AddMesh(const fbxsdk::FbxMesh* pFbxMesh, const char* pMeshName, std::optional<int32_t> optMaterialIndex, cd::Node* pParentNode, cd::SceneDatabase* pSceneDatabase)
+cd::MeshID FbxProducerImpl::AddMesh(const fbxsdk::FbxMesh* pFbxMesh, const char* pMeshName, std::optional<int32_t> optMaterialIndex, cd::NodeID parentNodeID, cd::SceneDatabase* pSceneDatabase)
 {
 	// For geometry data, we only query base layer which means index 0.
 	const fbxsdk::FbxLayer* pMeshBaseLayer = pFbxMesh->GetLayer(0);
@@ -500,9 +498,9 @@ cd::MeshID FbxProducerImpl::AddMesh(const fbxsdk::FbxMesh* pFbxMesh, const char*
 	mesh.SetVertexFormat(cd::MoveTemp(meshVertexFormat));
 
 	// Associate mesh id to its parent transform node.
-	if (pParentNode)
+	if (parentNodeID.IsValid())
 	{
-		pParentNode->AddMeshID(meshID.Data());
+		pSceneDatabase->GetNode(parentNodeID.Data()).AddMeshID(meshID.Data());
 	}
 
 	if (optMaterialIndex.has_value())

--- a/private/Producers/FbxProducer/FbxProducerImpl.cpp
+++ b/private/Producers/FbxProducer/FbxProducerImpl.cpp
@@ -841,15 +841,15 @@ int FbxProducerImpl::GetSceneBoneCount(const fbxsdk::FbxNode* pSceneNode)
 //	}
 //}
 
-cd::BoneID FbxProducerImpl::AddBone(const fbxsdk::FbxNode* pSDKNode, cd::Bone* pParentBone, cd::SceneDatabase* pSceneDatabase)
+cd::BoneID FbxProducerImpl::AddBone(const fbxsdk::FbxNode* pSDKNode, cd::BoneID parentBoneID, cd::SceneDatabase* pSceneDatabase)
 {
 	cd::BoneID boneID = m_boneIDGenerator.AllocateID();
 	cd::Bone bone(boneID, pSDKNode->GetName());
 	bone.SetTransform(details::ConvertFbxNodeTransform(const_cast<fbxsdk::FbxNode*>(pSDKNode)));
-	if (pParentBone)
+	if (parentBoneID.IsValid())
 	{
-		pParentBone->AddChildID(boneID.Data());
-		bone.SetParentID(pParentBone->GetID().Data());
+		pSceneDatabase->GetBone(parentBoneID.Data()).AddChildID(boneID.Data());
+		bone.SetParentID(parentBoneID.Data());
 	}
 	pSceneDatabase->AddBone(cd::MoveTemp(bone));
 

--- a/private/Producers/FbxProducer/FbxProducerImpl.h
+++ b/private/Producers/FbxProducer/FbxProducerImpl.h
@@ -86,7 +86,7 @@ private:
 	cd::MeshID AddMesh(const fbxsdk::FbxMesh* pFbxMesh, const char* pMeshName, std::optional<int32_t> optMaterialIndex, cd::NodeID parentNodeID, cd::SceneDatabase* pSceneDatabase);
 	std::vector<cd::MorphID> AddMorphs(const fbxsdk::FbxBlendShape* pBlendShape, const cd::Mesh& sourceMesh, const std::map<uint32_t, uint32_t>& mapVertexIDToControlPointIndex, cd::SceneDatabase* pSceneDatabase);
 
-	cd::BoneID AddBone(const fbxsdk::FbxNode* pSDKNode, cd::Bone* pParentNode, cd::SceneDatabase* pSceneDatabase);
+	cd::BoneID AddBone(const fbxsdk::FbxNode* pSDKNode, cd::BoneID parentBoneID, cd::SceneDatabase* pSceneDatabase);
 	//cd::TrackID AddTrack(const fbxsdk::FbxNode* pSDKNode, cd::Node* pParentNode, cd::SceneDatabase* pSceneDatabase);
 	cd::AnimationID AddAnimation(fbxsdk::FbxNode* pSDKNode, fbxsdk::FbxScene* pSDKScene, cd::SceneDatabase* pSceneDatabase);
 

--- a/private/Producers/FbxProducer/FbxProducerImpl.h
+++ b/private/Producers/FbxProducer/FbxProducerImpl.h
@@ -72,7 +72,7 @@ public:
 
 private:
 	int GetSceneNodeCount(const fbxsdk::FbxNode* pSceneNode);
-	void TraverseNodeRecursively(fbxsdk::FbxNode* pSDKNode, cd::Node* pParentNode, cd::SceneDatabase* pSceneDatabase);
+	void TraverseNodeRecursively(fbxsdk::FbxNode* pSDKNode, cd::NodeID parentNodeID, cd::SceneDatabase* pSceneDatabase);
 
 	int GetSceneBoneCount(const fbxsdk::FbxNode* pSceneNode);
 	//void TraverseBoneRecursively(fbxsdk::FbxNode* pSDKNode, fbxsdk::FbxScene* pSDKScene, cd::Bone* pParentNode, cd::SceneDatabase* pSceneDatabase);
@@ -81,9 +81,9 @@ private:
 	void AddMaterialTexture(const fbxsdk::FbxProperty& sdkProperty, cd::MaterialTextureType textureType, cd::Material& material, cd::SceneDatabase* pSceneDatabase);
 	cd::MaterialID AddMaterial(const fbxsdk::FbxSurfaceMaterial* pSDKMaterial, cd::SceneDatabase* pSceneDatabase);
 
-	cd::NodeID AddNode(const fbxsdk::FbxNode* pSDKNode, cd::Node* pParentNode, cd::SceneDatabase* pSceneDatabase);
+	cd::NodeID AddNode(const fbxsdk::FbxNode* pSDKNode, cd::NodeID parentNodeID, cd::SceneDatabase* pSceneDatabase);
 	cd::LightID AddLight(const fbxsdk::FbxLight* pFbxLight, const char* pLightName, cd::Transform transform, cd::SceneDatabase* pSceneDatabase);
-	cd::MeshID AddMesh(const fbxsdk::FbxMesh* pFbxMesh, const char* pMeshName, std::optional<int32_t> optMaterialIndex, cd::Node* pParentNode, cd::SceneDatabase* pSceneDatabase);
+	cd::MeshID AddMesh(const fbxsdk::FbxMesh* pFbxMesh, const char* pMeshName, std::optional<int32_t> optMaterialIndex, cd::NodeID parentNodeID, cd::SceneDatabase* pSceneDatabase);
 	std::vector<cd::MorphID> AddMorphs(const fbxsdk::FbxBlendShape* pBlendShape, const cd::Mesh& sourceMesh, const std::map<uint32_t, uint32_t>& mapVertexIDToControlPointIndex, cd::SceneDatabase* pSceneDatabase);
 
 	cd::BoneID AddBone(const fbxsdk::FbxNode* pSDKNode, cd::Bone* pParentNode, cd::SceneDatabase* pSceneDatabase);

--- a/private/Scene/SceneDatabase.cpp
+++ b/private/Scene/SceneDatabase.cpp
@@ -152,6 +152,11 @@ void SceneDatabase::SetMeshCount(uint32_t meshCount)
 	return m_pSceneDatabaseImpl->SetMeshCount(meshCount);
 }
 
+Mesh& SceneDatabase::GetMesh(uint32_t index)
+{
+	return m_pSceneDatabaseImpl->GetMesh(index);
+}
+
 const Mesh& SceneDatabase::GetMesh(uint32_t index) const
 {
 	return m_pSceneDatabaseImpl->GetMesh(index);
@@ -185,6 +190,11 @@ void SceneDatabase::SetMorphCount(uint32_t morphCount)
 	return m_pSceneDatabaseImpl->SetMorphCount(morphCount);
 }
 
+Morph& SceneDatabase::GetMorph(uint32_t index)
+{
+	return m_pSceneDatabaseImpl->GetMorph(index);
+}
+
 const Morph& SceneDatabase::GetMorph(uint32_t index) const
 {
 	return m_pSceneDatabaseImpl->GetMorph(index);
@@ -216,6 +226,11 @@ const std::vector<Material>& SceneDatabase::GetMaterials() const
 void SceneDatabase::SetMaterialCount(uint32_t materialCount)
 {
 	return m_pSceneDatabaseImpl->SetMaterialCount(materialCount);
+}
+
+Material& SceneDatabase::GetMaterial(uint32_t index)
+{
+	return m_pSceneDatabaseImpl->GetMaterial(index);
 }
 
 const Material& SceneDatabase::GetMaterial(uint32_t index) const
@@ -289,6 +304,11 @@ void SceneDatabase::SetCameraCount(uint32_t cameraCount)
 	return m_pSceneDatabaseImpl->SetCameraCount(cameraCount);
 }
 
+Camera& SceneDatabase::GetCamera(uint32_t index)
+{
+	return m_pSceneDatabaseImpl->GetCamera(index);
+}
+
 const Camera& SceneDatabase::GetCamera(uint32_t index) const
 {
 	return m_pSceneDatabaseImpl->GetCamera(index);
@@ -322,6 +342,11 @@ void SceneDatabase::SetLightCount(uint32_t lightCount)
 	return m_pSceneDatabaseImpl->SetLightCount(lightCount);
 }
 
+Light& SceneDatabase::GetLight(uint32_t index)
+{
+	return m_pSceneDatabaseImpl->GetLight(index);
+}
+
 const Light& SceneDatabase::GetLight(uint32_t index) const
 {
 	return m_pSceneDatabaseImpl->GetLight(index);
@@ -353,6 +378,11 @@ const std::vector<Bone>& SceneDatabase::GetBones() const
 void SceneDatabase::SetBoneCount(uint32_t boneCount)
 {
 	return m_pSceneDatabaseImpl->SetBoneCount(boneCount);
+}
+
+Bone& SceneDatabase::GetBone(uint32_t index)
+{
+	return m_pSceneDatabaseImpl->GetBone(index);
 }
 
 const Bone& SceneDatabase::GetBone(uint32_t index) const
@@ -393,6 +423,11 @@ void SceneDatabase::SetAnimationCount(uint32_t animationCount)
 	return m_pSceneDatabaseImpl->SetAnimationCount(animationCount);
 }
 
+Animation& SceneDatabase::GetAnimation(uint32_t index)
+{
+	return m_pSceneDatabaseImpl->GetAnimation(index);
+}
+
 const Animation& SceneDatabase::GetAnimation(uint32_t index) const
 {
 	return m_pSceneDatabaseImpl->GetAnimation(index);
@@ -424,6 +459,11 @@ const std::vector<Track>& SceneDatabase::GetTracks() const
 void SceneDatabase::SetTrackCount(uint32_t animationCount)
 {
 	return m_pSceneDatabaseImpl->SetTrackCount(animationCount);
+}
+
+Track& SceneDatabase::GetTrack(uint32_t index)
+{
+	return m_pSceneDatabaseImpl->GetTrack(index);
 }
 
 const Track& SceneDatabase::GetTrack(uint32_t index) const

--- a/private/Scene/SceneDatabase.cpp
+++ b/private/Scene/SceneDatabase.cpp
@@ -109,6 +109,11 @@ void SceneDatabase::SetNodeCount(uint32_t nodeCount)
 	return m_pSceneDatabaseImpl->SetNodeCount(nodeCount);
 }
 
+Node& SceneDatabase::GetNode(uint32_t index)
+{
+	return m_pSceneDatabaseImpl->GetNode(index);
+}
+
 const Node& SceneDatabase::GetNode(uint32_t index) const
 {
 	return m_pSceneDatabaseImpl->GetNode(index);

--- a/private/Scene/SceneDatabaseImpl.h
+++ b/private/Scene/SceneDatabaseImpl.h
@@ -57,6 +57,7 @@ public:
 	std::vector<Node>& GetNodes() { return m_nodes; }
 	const std::vector<Node>& GetNodes() const { return m_nodes; }
 	void SetNodeCount(uint32_t count) { m_nodes.reserve(count); }
+	Node& GetNode(uint32_t index) { return m_nodes[index]; }
 	const Node& GetNode(uint32_t index) const { return m_nodes[index]; }
 	const Node* GetNodeByName(const char* pName) const;
 	uint32_t GetNodeCount() const { return static_cast<uint32_t>(m_nodes.size()); }

--- a/private/Scene/SceneDatabaseImpl.h
+++ b/private/Scene/SceneDatabaseImpl.h
@@ -67,6 +67,7 @@ public:
 	std::vector<Mesh>& GetMeshes() { return m_meshes; }
 	const std::vector<Mesh>& GetMeshes() const { return m_meshes; }
 	void SetMeshCount(uint32_t count) { m_meshes.reserve(count); }
+	Mesh& GetMesh(uint32_t index) { return m_meshes[index];  }
 	const Mesh& GetMesh(uint32_t index) const { return m_meshes[index];  }
 	uint32_t GetMeshCount() const { return static_cast<uint32_t>(m_meshes.size()); }
 
@@ -75,6 +76,7 @@ public:
 	std::vector<Morph>& GetMorphs() { return m_morphs; }
 	const std::vector<Morph>& GetMorphs() const { return m_morphs; }
 	void SetMorphCount(uint32_t count) { m_morphs.reserve(count); }
+	Morph& GetMorph(uint32_t index) { return m_morphs[index]; }
 	const Morph& GetMorph(uint32_t index) const { return m_morphs[index]; }
 	uint32_t GetMorphCount() const { return static_cast<uint32_t>(m_morphs.size()); }
 
@@ -92,6 +94,7 @@ public:
 	std::vector<Material>& GetMaterials() { return m_materials; }
 	const std::vector<Material>& GetMaterials() const { return m_materials; }
 	void SetMaterialCount(uint32_t count) { m_materials.reserve(count); }
+	Material& GetMaterial(uint32_t index) { return m_materials[index]; }
 	const Material& GetMaterial(uint32_t index) const { return m_materials[index]; }
 	uint32_t GetMaterialCount() const { return static_cast<uint32_t>(m_materials.size()); }
 
@@ -100,6 +103,7 @@ public:
 	std::vector<Camera>& GetCameras() { return m_cameras; }
 	const std::vector<Camera>& GetCameras() const { return m_cameras; }
 	void SetCameraCount(uint32_t count) { m_cameras.reserve(count); }
+	Camera& GetCamera(uint32_t index) { return m_cameras[index]; }
 	const Camera& GetCamera(uint32_t index) const { return m_cameras[index]; }
 	uint32_t GetCameraCount() const { return static_cast<uint32_t>(m_cameras.size()); }
 
@@ -108,6 +112,7 @@ public:
 	std::vector<Light>& GetLights() { return m_lights; }
 	const std::vector<Light>& GetLights() const { return m_lights; }
 	void SetLightCount(uint32_t count) { m_lights.reserve(count); }
+	Light& GetLight(uint32_t index) { return m_lights[index]; }
 	const Light& GetLight(uint32_t index) const { return m_lights[index]; }
 	uint32_t GetLightCount() const { return static_cast<uint32_t>(m_lights.size()); }
 
@@ -116,6 +121,7 @@ public:
 	std::vector<Bone>& GetBones() { return m_bones; }
 	const std::vector<Bone>& GetBones() const { return m_bones; }
 	void SetBoneCount(uint32_t count) { m_bones.reserve(count); }
+	Bone& GetBone(uint32_t index) { return m_bones[index]; }
 	const Bone& GetBone(uint32_t index) const { return m_bones[index]; }
 	const Bone* GetBoneByName(const char* pName) const;
 	uint32_t GetBoneCount() const { return static_cast<uint32_t>(m_bones.size()); }
@@ -125,6 +131,7 @@ public:
 	std::vector<Animation>& GetAnimations() { return m_animations; }
 	const std::vector<Animation>& GetAnimations() const { return m_animations; }
 	void SetAnimationCount(uint32_t count) { m_animations.reserve(count); }
+	Animation& GetAnimation(uint32_t index) { return m_animations[index]; }
 	const Animation& GetAnimation(uint32_t index) const { return m_animations[index]; }
 	uint32_t GetAnimationCount() const { return static_cast<uint32_t>(m_animations.size()); }
 
@@ -133,6 +140,7 @@ public:
 	std::vector<Track>& GetTracks() { return m_tracks; }
 	const std::vector<Track>& GetTracks() const { return m_tracks; }
 	void SetTrackCount(uint32_t count) { m_tracks.reserve(count); }
+	Track& GetTrack(uint32_t index) { return m_tracks[index]; }
 	const Track& GetTrack(uint32_t index) const { return m_tracks[index]; }
 	const Track* GetTrackByName(const char* pName) const;
 	uint32_t GetTrackCount() const { return static_cast<uint32_t>(m_tracks.size()); }

--- a/public/Scene/SceneDatabase.h
+++ b/public/Scene/SceneDatabase.h
@@ -70,6 +70,7 @@ public:
 	std::vector<Mesh>& GetMeshes();
 	const std::vector<Mesh>& GetMeshes() const;
 	void SetMeshCount(uint32_t meshCount);
+	Mesh& GetMesh(uint32_t index);
 	const Mesh& GetMesh(uint32_t index) const;
 	uint32_t GetMeshCount() const;
 
@@ -78,6 +79,7 @@ public:
 	std::vector<Morph>& GetMorphs();
 	const std::vector<Morph>& GetMorphs() const;
 	void SetMorphCount(uint32_t morphCount);
+	Morph& GetMorph(uint32_t index);
 	const Morph& GetMorph(uint32_t index) const;
 	uint32_t GetMorphCount() const;
 
@@ -86,6 +88,7 @@ public:
 	std::vector<Material>& GetMaterials();
 	const std::vector<Material>& GetMaterials() const;
 	void SetMaterialCount(uint32_t materialCount);
+	Material& GetMaterial(uint32_t index);
 	const Material& GetMaterial(uint32_t index) const;
 	uint32_t GetMaterialCount() const;
 
@@ -103,6 +106,7 @@ public:
 	std::vector<Camera>& GetCameras();
 	const std::vector<Camera>& GetCameras() const;
 	void SetCameraCount(uint32_t cameraCount);
+	Camera& GetCamera(uint32_t index);
 	const Camera& GetCamera(uint32_t index) const;
 	uint32_t GetCameraCount() const;
 
@@ -111,6 +115,7 @@ public:
 	std::vector<Light>& GetLights();
 	const std::vector<Light>& GetLights() const;
 	void SetLightCount(uint32_t lightCount);
+	Light& GetLight(uint32_t index);
 	const Light& GetLight(uint32_t index) const;
 	uint32_t GetLightCount() const;
 
@@ -119,6 +124,7 @@ public:
 	std::vector<Bone>& GetBones();
 	const std::vector<Bone>& GetBones() const;
 	void SetBoneCount(uint32_t boneCount);
+	Bone& GetBone(uint32_t index);
 	const Bone& GetBone(uint32_t index) const;
 	const Bone* GetBoneByName(const char* pName) const;
 	uint32_t GetBoneCount() const;
@@ -128,6 +134,7 @@ public:
 	std::vector<Animation>& GetAnimations();
 	const std::vector<Animation>& GetAnimations() const;
 	void SetAnimationCount(uint32_t animationCount);
+	Animation& GetAnimation(uint32_t index);
 	const Animation& GetAnimation(uint32_t index) const;
 	uint32_t GetAnimationCount() const;
 
@@ -136,6 +143,7 @@ public:
 	std::vector<Track>& GetTracks();
 	const std::vector<Track>& GetTracks() const;
 	void SetTrackCount(uint32_t TrackCount);
+	Track& GetTrack(uint32_t index);
 	const Track& GetTrack(uint32_t index) const;
 	const Track* GetTrackByName(const char* pName) const;
 	uint32_t GetTrackCount() const;

--- a/public/Scene/SceneDatabase.h
+++ b/public/Scene/SceneDatabase.h
@@ -60,6 +60,7 @@ public:
 	std::vector<Node>& GetNodes();
 	const std::vector<Node>& GetNodes() const;
 	void SetNodeCount(uint32_t nodeCount);
+	Node& GetNode(uint32_t index);
 	const Node& GetNode(uint32_t index) const;
 	const Node* GetNodeByName(const char* pName) const;
 	uint32_t GetNodeCount() const;


### PR DESCRIPTION
Fix #234 .
Instead of passing pointers, it is more safe to pass ObjectID.

Test result after fix:
```
FBXSDK Version : 7, 7, 0
FBXFile Version : 7, 4, 0

SceneDatabase :
        Name : G:\ArtAssets\TestAssets\BadCases\walk_from_blender\walk_from_blender.fbx
        AABB :
                Min : (x = -95.136635, y = -0.427658, z = -20.716028)
                Max : (x = 95.095535, y = 200.076752, z = 26.151720)
        AxisSystem :
                Handedness : LeftHandSystem
                UpAxis : (x = 0.000000, y = 1.000000, z = 0.000000)
                FrontAxis : (x = 1.000000, y = 0.000000, z = 0.000000)
        UnitSystem :
                Unit : CenterMeter
        Node count : 2
        Mesh count : 1
        Morph count : 0
        Material count : 1
        Texture count : 2
        Camera count : 0
        Light count : 0
        Bone count : 0
        Animation count : 0
        Track count : 0

[Node 0] ParentID = 4294967295, Name = RootNode
        Translation : (x = 0.000000, y = 0.000000, z = 0.000000)
        Rotation : (w = 1.000000, x = 0.000000, y = 0.000000, z = 0.000000)
        Scale : (x = 1.000000, y = 1.000000, z = 1.000000)
[Node 1] ParentID = 4294967295, Name = Armature
        Translation : (x = 0.000000, y = 0.000000, z = 0.000000)
        Rotation : (w = 1.000000, x = -0.000000, y = 0.000000, z = 0.000000)
        Scale : (x = 1.000000, y = 1.000000, z = 1.000000)

[Mesh 0] Name = Akai
        VertexCount = 31158, TriangleCount = 10386
        [Associated Material 0]

[MaterialID 0] Name = Akai_MAT
        Metallic = 0.100000
        Roughness = 0.900000
        [Associated Texture 0] Type = BaseColor
                Path = C:\Users\V\Desktop\model\TestAssets-main\Downloads\Catwalk Walk Turn 180 Tight.fbm\akai_diffuse.png
                UVScale : (x = 1.000000, y = 1.000000)
                UVOffset : (x = 0.000000, y = 0.000000)
        [Associated Texture 1] Type = Normal
                Path = C:\Users\V\Desktop\model\zachary\Dropbox (Adobe)\Mixamo\Characters\Akai E Espiritu\akai_e_espiritu_20210811.fbm\akai_normal.png
                UVScale : (x = 1.000000, y = 1.000000)
                UVOffset : (x = 0.000000, y = 0.000000)
        [Associated Mesh 0] Akai

[Texture 0] Type = BaseColor
        Name = base_color_texture
        Path = C:\Users\V\Desktop\model\TestAssets-main\Downloads\Catwalk Walk Turn 180 Tight.fbm\akai_diffuse.png
        UVMapMode = (Wrap, Wrap)
[Texture 1] Type = Normal
        Name = normalmap_texture
        Path = C:\Users\V\Desktop\model\zachary\Dropbox (Adobe)\Mixamo\Characters\Akai E Espiritu\akai_e_espiritu_20210811.fbm\akai_normal.png
        UVMapMode = (Wrap, Wrap)

AssetPipeline costs 0.566786 seconds
```